### PR TITLE
2 lines of doc...

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -125,7 +125,9 @@ lib/guard/guard-name.rb inherit from guard/guard and should overwrite at least o
           true
         end
         
-        # Call with Ctrl-C signal (when Guard quit)
+        # Call with Ctrl-C signal (when Guard quit).
+        # This method must return a true value 
+        # if everything went well or guard will not stop.
         def stop
           true
         end

--- a/lib/guard/guard.rb
+++ b/lib/guard/guard.rb
@@ -30,6 +30,7 @@ module Guard
       true
     end
     
+    # Retrieve a true value if the instance successfuly stopped
     def stop
       true
     end


### PR DESCRIPTION
... to say that the stop method of the Guard interface must retrieve a 'true' value in case everything went well.
It take me around 2 hours to figure out why my plug-in was preventing guard to shutdown on ctrl+c.

Hi guys,

Your library is working pretty well with my Rails project and the descriptor is much cleaner than it was with watchr. Thank You for that!

By the way, I'm wondering what is the purpose of this check on stop (interactor.rb, line 15) ? You might want to implement a timeout for the method to return but really not to keep the app running if a plug-in is buggy.

As a user, when I use the ctrl+c command, I really want my console application to shutdown, even if something went wrong.

I can remove the check on stop and add begin/rescue block arround the method calls to prevent bad implementation if you agree on this behavior. Probably some test on the interface are missing as well (with a mock implementation for exemple).
