### PR TITLE
new supervised_task method + stop refactored

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -131,14 +131,15 @@ lib/guard/guard-name.rb inherit from guard/guard and should overwrite at least o
         # = Guard method =
         # ================
         
+        # If one of those methods raise an exception, the Guard instance
+        # will be removed from the active guard.
+        
         # Call once when guard starts
         def start
           true
         end
         
-        # Call with Ctrl-C signal (when Guard quit).
-        # This method must return a true value 
-        # if everything went well or guard will not stop.
+        # Call with Ctrl-C signal (when Guard quit)
         def stop
           true
         end

--- a/lib/guard/guard.rb
+++ b/lib/guard/guard.rb
@@ -30,7 +30,6 @@ module Guard
       true
     end
     
-    # Retrieve a true value if the instance successfuly stopped
     def stop
       true
     end

--- a/lib/guard/interactor.rb
+++ b/lib/guard/interactor.rb
@@ -5,25 +5,22 @@ module Guard
       # Run all (Ctrl-\)
       Signal.trap('QUIT') do
         ::Guard.run do
-          ::Guard.guards.each { |g| g.run_all }
+          ::Guard.guards.each { |g| ::Guard.supervised_task g, :run_all }
         end
       end
       
       # Stop (Ctrl-C)
       Signal.trap('INT') do
         ::Guard.listener.stop
-        if ::Guard.guards.all? { |g| g.stop }
-          UI.info "Bye bye...", :reset => true
-          abort("\n")
-        else
-          ::Guard.listener.start
-        end
+        ::Guard.guards.each { |g| ::Guard.supervised_task g, :stop }
+        UI.info "Bye bye...", :reset => true
+        abort("\n")
       end
       
       # Reload (Ctrl-Z)
       Signal.trap('TSTP') do
         ::Guard.run do
-          ::Guard.guards.each { |g| g.reload }
+          ::Guard.guards.each { |g| ::Guard.supervised_task g, :reload }
         end
       end
     end

--- a/spec/guard_spec.rb
+++ b/spec/guard_spec.rb
@@ -1,5 +1,19 @@
 require 'spec_helper'
 
+# mute UI
+module Guard::UI
+  class << self
+    def info(message, options = {})
+    end
+    
+    def error(message)
+    end
+    
+    def debug(message)
+    end
+  end
+end
+
 describe Guard do
   
   describe "get_guard_class" do
@@ -18,6 +32,66 @@ describe Guard do
       guard_path.should == guard_path.chomp
     end
     
+  end
+  
+  describe "init" do
+    subject { ::Guard.init }
+    
+    it "Should retrieve itself for chaining" do
+      subject.should be_kind_of Module
+    end
+    
+    it "Should init guards array" do
+      ::Guard.guards.should be_kind_of Array
+    end
+    
+    it "Should init options" do
+      opts = {:my_opts => true}
+      ::Guard.init(opts).options.should be_include :my_opts
+    end
+    
+    it "Should init listeners" do
+      ::Guard.listener.should be_kind_of Guard::Listener
+    end
+  end
+  
+  describe "supervised_task" do
+    subject {::Guard.init}
+    
+    before :each do
+      @g = mock(Guard::Guard)
+      @g.stub!(:regular).and_return { true }
+      @g.stub!(:spy).and_return { raise "I break your system" }
+      @g.stub!(:pirate).and_raise Exception.new("I blow your system up")
+      @g.stub!(:regular_arg).with("given_path").and_return { "given_path" }
+      subject.guards.push @g
+    end
+    
+    it "should let it go when nothing special occurs" do
+      subject.guards.should be_include @g
+      subject.supervised_task(@g, :regular).should be_true
+      subject.guards.should be_include @g
+    end
+    
+    it "should let it work with some tools" do
+      subject.guards.should be_include @g
+      subject.supervised_task(@g, :regular).should be_true
+      subject.guards.should be_include @g
+    end
+    
+    it "should fire the guard on spy act discovery" do
+      subject.guards.should be_include @g
+      ::Guard.supervised_task(@g, :spy).should be_kind_of Exception
+      subject.guards.should_not be_include @g
+      ::Guard.supervised_task(@g, :spy).message.should == 'I break your system'
+    end
+    
+    it "should fire the guard on pirate act discovery" do
+      subject.guards.should be_include @g
+      ::Guard.supervised_task(@g, :regular_arg, "given_path").should be_kind_of String
+      subject.guards.should be_include @g
+      ::Guard.supervised_task(@g, :regular_arg, "given_path").should == "given_path"
+    end
   end
   
 end


### PR DESCRIPTION
All guard task (start, stop, ...) now execute through supervised_task method which prevent a guard from killing the whole application. In case a guard task raise an exception, the guard is removed from the list and a UI.error message is produced.

On ctrl+c, the application quit even if a stop method return a 'false' evaluated value, no more check are done on the method result.
