### PR TITLE
Linux listener fix - deduplicate files

### DIFF
--- a/lib/guard/listeners/linux.rb
+++ b/lib/guard/listeners/linux.rb
@@ -60,6 +60,7 @@ module Guard
           update_last_event
 
           unless files.empty?
+            files.uniq!
             files.map! { |file| file.gsub("#{Dir.pwd}/", '') }
             callback.call(files)
             files.clear


### PR DESCRIPTION
commit message should be self-explanatory.

To write unit-tests I would have to extract "unless files.empty? .... end" block. I tried that but I have little experience with Ruby so I hit few problems, for example how to test private methods and so. Please let me know if you would like me to write them.
