### PR TITLE
fix/ui-reset-line

### DIFF
--- a/lib/guard/ui.rb
+++ b/lib/guard/ui.rb
@@ -24,7 +24,7 @@ module Guard
       end
       
       def reset_line
-        print "\r\e "
+        print "\r\e[0m"
       end
       
       def clear


### PR DESCRIPTION
Fixes an invalid ANSI escape code in UI.reset_line. I assumed that with naming the method reset_line an actual reset of things like color and bold is meant, not just a carriage return.
