### PR TITLE
Fix "guard init" command

### DIFF
--- a/lib/guard.rb
+++ b/lib/guard.rb
@@ -91,7 +91,7 @@ module Guard
     end
 
     def locate_guard(name)
-      `gem which guard/#{name}`.chomp
+      Gem.source_index.find_name("guard-#{name}").last.full_gem_path
     rescue
       UI.error "Could not find 'guard-#{name}' gem path."
     end


### PR DESCRIPTION
Commit 59f555e086ba32e7b85d619746ac28c508ad53f9 introduced a following problem, Gem.locate_guard returns incorrect path. 

Before aforementioned commit the method was returning a path to gem folder, eg:

```
$ gem open guard-minitest --latest --command echo
/Users/brainopia/.rvm/gems/ruby-1.8.7-p334/gems/guard-minitest-0.3.0
```

But after the commit it returns:

```
$ gem which guard/minitest
```

And since Guard::Guard.init depends on this method, there is an error when you trying to init specific guard:

```
$  guard init minitest
Writing new Guardfile to /Users/brainopia/code/rails/ororo/Guardfile
/Users/brainopia/.rvm/gems/ruby-1.9.2-p180/gems/guard-0.3.1/lib/guard/guard.rb:15:in `read': Not a directory - /Users/brainopia/.rvm/gems/ruby-1.9.2-p180/gems/guard-minitest-0.3.0/lib/guard/minitest.rb/lib/guard/minitest/templates/Guardfile (Errno::ENOTDIR)
```

I've fixed this problem without reintroducing dependency on open_gem with following line of code:

```
Gem.source_index.find_name("guard-#{name}").last.full_gem_path
```
