### PR TITLE
Adding support for inline Guard classes rather than requiring a gem

### DIFF
--- a/lib/guard.rb
+++ b/lib/guard.rb
@@ -83,10 +83,15 @@ module Guard
     end
 
     def get_guard_class(name)
-      require "guard/#{name.downcase}"
+      try_to_load_gem name
       self.const_get(self.constants.find{|klass_name| klass_name.to_s.downcase == name.downcase })
+    rescue TypeError
+      UI.error "Could not find load find gem 'guard-#{name}' or find class Guard::#{name}"
+    end
+
+    def try_to_load_gem(name)
+      Kernel.require "guard/#{name.downcase}"
     rescue LoadError
-      UI.error "Could not find gem 'guard-#{name}', please add it in your Gemfile."
     end
 
     def locate_guard(name)

--- a/spec/guard_spec.rb
+++ b/spec/guard_spec.rb
@@ -30,15 +30,30 @@ describe Guard do
     end
 
     describe ".get_guard_class" do
-      it "should return Guard::RSpec" do
-        Guard.get_guard_class('rspec').should == Guard::RSpec
+      it "should report an error if the class is not found" do
+        ::Guard::UI.should_receive(:error)
+        Guard.get_guard_class('notAGuardClass')
       end
 
       context 'loaded some nested classes' do
-        it "should return Guard::RSpec" do
-          require 'guard/rspec'
-          Guard::RSpec.class_eval('class NotGuardClass; end')
-          Guard.get_guard_class('rspec').should == Guard::RSpec
+        it "should find and return loaded class" do
+          Kernel.should_receive(:require) { |file_name|
+            file_name.should == 'guard/classname'
+            class Guard::Classname
+            end
+          }
+          Guard.get_guard_class('classname').should == Guard::Classname
+        end
+      end
+
+      context 'loaded some inline classes ' do
+        it 'should return inline class' do
+          module Guard
+            class Inline < Guard
+            end
+          end
+
+          Guard.get_guard_class('inline').should == Guard::Inline
         end
       end
     end


### PR DESCRIPTION
I added the ability to inline a guard class in the guardfile itself rather than going out to a gem for everything.  This could be useful when there are complex things you may need to run as opposed to the guard-shell gem which only lets you 'run on change'.  I have some custom things I would like to guard and would rather not create a gem for it.  Guard will attempt to load the gem as before and then look for a class.  If it is inline it will get picked up.

Here is an example of a Guardfile with what I am describing as an inline guard class:

require 'guard/guard'

module ::Guard
  class Example < ::Guard::Guard
    def run_on_change(paths)
      puts 'hello'
    end
  end
end

guard 'example' do
  watch(%r{.*})
end
