### PR TITLE
Allow options (like :priority) to be passed through to Growl

### DIFF
--- a/lib/guard/notifier.rb
+++ b/lib/guard/notifier.rb
@@ -10,12 +10,12 @@ module Guard
 
     def self.notify(message, options = {})
       unless @disable || ENV["GUARD_ENV"] == "test"
-        image = options[:image] || :success
-        title = options[:title] || "Guard"
+        image = options.delete(:image) || :success
+        options[:title] ||= "Guard"
         case Config::CONFIG['target_os']
         when /darwin/i
           if growl_installed?
-            Growl.notify message, :title => title, :icon => image_path(image), :name => "Guard"
+            Growl.notify message, options.merge(:icon => image_path(image), :name => "Guard")
           end
         when /linux/i
           if libnotify_installed?


### PR DESCRIPTION
This change allows guard plugins (like guard-rspec) to pass options (like :priority) up to the Growl notifier. With this change, things like indirect/rspec-guard@d2f01d69a7aa2d8c4ea01586618f26422680bbf0 are possible, and the growl notification colors can be customized depending on the outcome of the spec run.
