### PR TITLE
Fix spec on JRuby that was failing due to different execution order

### DIFF
--- a/lib/guard/notifier.rb
+++ b/lib/guard/notifier.rb
@@ -8,6 +8,10 @@ module Guard
       @disable = true
     end
 
+    def self.turn_on
+      @disable = nil
+    end
+
     def self.notify(message, options = {})
       unless @disable || ENV["GUARD_ENV"] == "test"
         image = options[:image] || :success

--- a/spec/guard/notifier_spec.rb
+++ b/spec/guard/notifier_spec.rb
@@ -7,6 +7,7 @@ describe Guard::Notifier do
     before(:each) do
       @saved_guard_env = ENV["GUARD_ENV"]
       ENV["GUARD_ENV"] = 'dont_mute_notify'
+      subject.turn_on
     end
 
     if mac?


### PR DESCRIPTION
This spec was failing on JRuby:

```
1) Guard::Notifier.notify uses Growl on Mac OS X
 Failure/Error: Growl.should_receive(:notify).with("great",
   (Growl).notify("great", {:title=>"Guard", :icon=>"/Users/nicksieger/Projects/ruby/guard/images/success.png", :name=>"Guard"})
       expected: 1 time
       received: 0 times
 # ./spec/guard/notifier_spec.rb:15:in `(root)'
 # org/jruby/RubyArray.java:1602:in `each'
 # org/jruby/RubyArray.java:1602:in `each'
 # org/jruby/RubyArray.java:1602:in `each'
 # org/jruby/RubyKernel.java:1191:in `catch'
 # org/jruby/RubyArray.java:2336:in `collect'
 # org/jruby/RubyArray.java:2336:in `collect'
 # org/jruby/RubyArray.java:2336:in `collect'
 # org/jruby/RubyProc.java:268:in `call'
 # org/jruby/RubyProc.java:232:in `call'
```

Setting notifier on before the spec ensures it is always set up to receive the notify method call.
