### PR TITLE
Extract code from signal handlers into methods

### DIFF
--- a/lib/guard/interactor.rb
+++ b/lib/guard/interactor.rb
@@ -1,29 +1,41 @@
 module Guard
   module Interactor
-    
+    extend self
+
+    def run_all
+      ::Guard.run do
+        ::Guard.guards.each { |guard| ::Guard.supervised_task(guard, :run_all) }
+      end
+    end
+
+    def stop
+      UI.info "Bye bye...", :reset => true
+      ::Guard.listener.stop
+      ::Guard.guards.each { |guard| ::Guard.supervised_task(guard, :stop) }
+      abort("\n")
+    end
+
+    def reload
+      ::Guard.run do
+        ::Guard.guards.each { |guard| ::Guard.supervised_task(guard, :reload) }
+      end
+    end
+
     def self.init_signal_traps
       # Run all (Ctrl-\)
       Signal.trap('QUIT') do
-        ::Guard.run do
-          ::Guard.guards.each { |guard| ::Guard.supervised_task(guard, :run_all) }
-        end
+        run_all
       end
-      
+
       # Stop (Ctrl-C)
       Signal.trap('INT') do
-        UI.info "Bye bye...", :reset => true
-        ::Guard.listener.stop
-        ::Guard.guards.each { |guard| ::Guard.supervised_task(guard, :stop) }
-        abort("\n")
+        stop
       end
-      
+
       # Reload (Ctrl-Z)
       Signal.trap('TSTP') do
-        ::Guard.run do
-          ::Guard.guards.each { |guard| ::Guard.supervised_task(guard, :reload) }
-        end
+        reload
       end
     end
-    
   end
 end

--- a/spec/guard/interactor_spec.rb
+++ b/spec/guard/interactor_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Guard::Interactor do
+  subject { Guard::Interactor }
+  let(:guard) { mock "guard" }
+  before :each do
+    Guard.stub!(:guards).and_return([guard])
+    Guard.stub!(:listener).and_return(mock(:start => nil, :stop => nil))
+  end
+
+  it ".run_all should send :run_all to all guards" do
+    guard.should_receive(:run_all)
+    subject.run_all
+  end
+
+  it ".stop should send :stop to all guards" do
+    guard.should_receive(:stop)
+    lambda { subject.stop }.should raise_error(SystemExit)
+  end
+
+  it ".reload should send :reload to all guards" do
+    guard.should_receive(:reload)
+    subject.reload
+  end
+end


### PR DESCRIPTION
This will allow building other mechanisms to interact with Guard, for
example on JRuby, where signal handling tends to be unreliable.

For example, I'm planning on making a JMX-based interactor for JRuby. Maybe a little bit heavy-weight, and sucks that we can't use signals, but it's a fun exercise.
