### PR TITLE
Support for dashes in guard names

### DIFF
--- a/lib/guard.rb
+++ b/lib/guard.rb
@@ -82,7 +82,7 @@ module Guard
 
     def get_guard_class(name)
       try_to_load_gem name
-      self.const_get(self.constants.find{ |klass_name| klass_name.to_s.downcase == name.downcase })
+      self.const_get(self.constants.find{ |klass_name| klass_name.to_s.downcase == name.downcase.gsub('-', '') })
     rescue TypeError
       UI.error "Could not find load find gem 'guard-#{name}' or find class Guard::#{name}"
     end

--- a/spec/guard_spec.rb
+++ b/spec/guard_spec.rb
@@ -57,6 +57,17 @@ describe Guard do
       end
     end
 
+    context 'with a name with dashes' do
+      it "returns the Guard class" do
+        Guard.should_receive(:try_to_load_gem) { |classname|
+          classname.should == 'dashed-class-name'
+          class Guard::DashedClassName
+          end
+        }
+        Guard.get_guard_class('dashed-class-name').should == Guard::DashedClassName
+      end
+    end
+
     context 'with an inline Guard class' do
       it 'returns the Guard class' do
         module Guard


### PR DESCRIPTION
I want to release a guard gem for `jasmine-headless-webkit`, and, before this patch, the class name `Guard::JasmineHeadlessWebkit` was unresolvable due to the preservation of dashes in the class name search. This removes the dashes from the class name search string so that the class name can be found correctly.
