### PR TITLE
Symbols for group names

### DIFF
--- a/lib/guard/dsl.rb
+++ b/lib/guard/dsl.rb
@@ -90,7 +90,7 @@ module Guard
     end
 
     def group(name, &guard_definition)
-      guard_definition.call if guard_definition && (@@options[:group].empty? || @@options[:group].include?(name))
+      guard_definition.call if guard_definition && (@@options[:group].empty? || @@options[:group].include?(name.to_s))
     end
 
     def guard(name, options = {}, &watch_definition)

--- a/spec/guard/dsl_spec.rb
+++ b/spec/guard/dsl_spec.rb
@@ -251,7 +251,7 @@ private
   end
 
   def valid_guardfile_string
-   "group 'x' do
+   "group :x do
       guard 'test' do
         watch('c')
       end


### PR DESCRIPTION
I tried to treat my Guardfile group like my Gemfile groups and couldn't because symbols weren't being recognized in the group enumeration. This patch ensures symbols work as group names.
