### PR TITLE
Temporary fix for stack level too deep on Windows

### DIFF
--- a/lib/guard/ui.rb
+++ b/lib/guard/ui.rb
@@ -5,7 +5,8 @@ module Guard
       def info(message, options = {})
         unless ENV["GUARD_ENV"] == "test"
           reset_line if options[:reset]
-          puts reset_color(message) if message != ''
+          # The line below causes a stack level too deep error on Windows
+          # puts reset_color(message) if message != ''
         end
       end
 


### PR DESCRIPTION
This is a follow up to https://github.com/guard/guard/issues/12

Commenting out line#8 in ui.rb seems to fix a stack level too deep error on Windows.
