### PR TITLE
Use RbConfig instead of obsolete and deprecated Config.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,15 +6,15 @@ gem 'rake'
 
 require 'rbconfig'
 
-if Config::CONFIG['target_os'] =~ /darwin/i
+if RbConfig::CONFIG['target_os'] =~ /darwin/i
   gem 'rb-fsevent', '>= 0.4.0', :require => false
   gem 'growl',      '~> 1.0.3', :require => false
 end
-if Config::CONFIG['target_os'] =~ /linux/i
+if RbConfig::CONFIG['target_os'] =~ /linux/i
   gem 'rb-inotify', '>= 0.8.5', :require => false
   gem 'libnotify',  '~> 0.1.3', :require => false
 end
-if Config::CONFIG['target_os'] =~ /mswin|mingw/i
+if RbConfig::CONFIG['target_os'] =~ /mswin|mingw/i
   gem 'win32console', :require => false
   gem 'rb-fchange', '>= 0.0.2', :require => false
   gem 'rb-notifu', '>= 0.0.4', :require => false

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ task :default => :spec
 
 require 'rbconfig'
 namespace(:spec) do
-  if Config::CONFIG['host_os'] =~ /mswin|mingw/i
+  if RbConfig::CONFIG['host_os'] =~ /mswin|mingw/i
     desc "Run all specs on multiple ruby versions (requires pik)"
     task(:portability) do
       %w[187 192 161].each do |version|

--- a/lib/guard/listener.rb
+++ b/lib/guard/listener.rb
@@ -116,15 +116,15 @@ module Guard
     end
 
     def self.mac?
-      Config::CONFIG['target_os'] =~ /darwin/i
+      RbConfig::CONFIG['target_os'] =~ /darwin/i
     end
 
     def self.linux?
-      Config::CONFIG['target_os'] =~ /linux/i
+      RbConfig::CONFIG['target_os'] =~ /linux/i
     end
 
     def self.windows?
-      Config::CONFIG['target_os'] =~ /mswin|mingw/i
+      RbConfig::CONFIG['target_os'] =~ /mswin|mingw/i
     end
 
   end

--- a/lib/guard/listeners/linux.rb
+++ b/lib/guard/listeners/linux.rb
@@ -58,7 +58,7 @@ module Guard
     def watch_change
       @watch_change = true
       until @stop
-        if Config::CONFIG['build'] =~ /java/ || IO.select([inotify.to_io], [], [], latency)
+        if RbConfig::CONFIG['build'] =~ /java/ || IO.select([inotify.to_io], [], [], latency)
           break if @stop
 
           sleep latency

--- a/lib/guard/notifier.rb
+++ b/lib/guard/notifier.rb
@@ -11,7 +11,7 @@ module Guard
 
     def self.turn_on
       ENV["GUARD_NOTIFY"] = 'true'
-      case Config::CONFIG['target_os']
+      case RbConfig::CONFIG['target_os']
       when /darwin/i
         require_growl
       when /linux/i
@@ -26,7 +26,7 @@ module Guard
         image = options.delete(:image) || :success
         title = options.delete(:title) || "Guard"
 
-        case Config::CONFIG['target_os']
+        case RbConfig::CONFIG['target_os']
         when /darwin/i
           notify_mac(title, message, image, options)
         when /linux/i

--- a/lib/guard/ui.rb
+++ b/lib/guard/ui.rb
@@ -50,7 +50,7 @@ module Guard
       end
 
       def color_enabled?
-        @color_enabled ||= if Config::CONFIG['target_os'] =~ /mswin|mingw/i
+        @color_enabled ||= if RbConfig::CONFIG['target_os'] =~ /mswin|mingw/i
           unless ENV['ANSICON']
             begin
               require 'rubygems' unless ENV['NO_RUBYGEMS']

--- a/spec/guard/listener_spec.rb
+++ b/spec/guard/listener_spec.rb
@@ -4,25 +4,25 @@ describe Guard::Listener do
   subject { Guard::Listener }
 
   describe ".select_and_init" do
-    before(:each) { @target_os = Config::CONFIG['target_os'] }
-    after(:each) { Config::CONFIG['target_os'] = @target_os }
+    before(:each) { @target_os = RbConfig::CONFIG['target_os'] }
+    after(:each) { RbConfig::CONFIG['target_os'] = @target_os }
 
     it "uses the Darwin listener on Mac OS X" do
-      Config::CONFIG['target_os'] = 'darwin10.4.0'
+      RbConfig::CONFIG['target_os'] = 'darwin10.4.0'
       Guard::Darwin.stub(:usable?).and_return(true)
       Guard::Darwin.should_receive(:new)
       subject.select_and_init
     end
 
     it "uses the Windows listener on Windows" do
-      Config::CONFIG['target_os'] = 'mingw'
+      RbConfig::CONFIG['target_os'] = 'mingw'
       Guard::Windows.stub(:usable?).and_return(true)
       Guard::Windows.should_receive(:new)
       subject.select_and_init
     end
 
     it "uses the Linux listener on Linux" do
-      Config::CONFIG['target_os'] = 'linux'
+      RbConfig::CONFIG['target_os'] = 'linux'
       Guard::Linux.stub(:usable?).and_return(true)
       Guard::Linux.should_receive(:new)
       subject.select_and_init
@@ -157,6 +157,5 @@ describe Guard::Listener do
     end
 
   end
-
 
 end

--- a/spec/guard/notifier_spec.rb
+++ b/spec/guard/notifier_spec.rb
@@ -17,7 +17,7 @@ describe Guard::Notifier do
   describe ".turn_on" do
     context "on Mac OS" do
       before do
-        Config::CONFIG.should_receive(:[]).with('target_os').and_return 'darwin'
+        RbConfig::CONFIG.should_receive(:[]).with('target_os').and_return 'darwin'
       end
 
       context "with the Growl library available" do
@@ -39,7 +39,7 @@ describe Guard::Notifier do
 
     context "on Linux" do
       before do
-        Config::CONFIG.should_receive(:[]).with('target_os').and_return 'linux'
+        RbConfig::CONFIG.should_receive(:[]).with('target_os').and_return 'linux'
       end
 
       context "with the Libnotify library available" do
@@ -61,7 +61,7 @@ describe Guard::Notifier do
 
     context "on Windows" do
       before do
-        Config::CONFIG.should_receive(:[]).with('target_os').and_return 'mswin'
+        RbConfig::CONFIG.should_receive(:[]).with('target_os').and_return 'mswin'
       end
 
       context "with the rb-notifu library available" do
@@ -87,7 +87,7 @@ describe Guard::Notifier do
 
     context "on Mac OS" do
       before do
-        Config::CONFIG.should_receive(:[]).with('target_os').and_return 'darwin'
+        RbConfig::CONFIG.should_receive(:[]).with('target_os').and_return 'darwin'
         subject.stub(:require_growl)
         Object.send(:remove_const, :Growl) if defined?(Growl)
         Growl = Object.new
@@ -134,7 +134,7 @@ describe Guard::Notifier do
 
     context "on Linux" do
       before do
-        Config::CONFIG.should_receive(:[]).with('target_os').and_return 'linux'
+        RbConfig::CONFIG.should_receive(:[]).with('target_os').and_return 'linux'
         subject.stub(:require_libnotify)
         Object.send(:remove_const, :Libnotify) if defined?(Libnotify)
         Libnotify = Object.new
@@ -181,7 +181,7 @@ describe Guard::Notifier do
 
     context "on Windows" do
       before do
-        Config::CONFIG.should_receive(:[]).with('target_os').and_return 'mswin'
+        RbConfig::CONFIG.should_receive(:[]).with('target_os').and_return 'mswin'
         subject.stub(:require_rbnotifu)
         Object.send(:remove_const, :Notifu) if defined?(Notifu)
         Notifu = Object.new

--- a/spec/support/platform_helper.rb
+++ b/spec/support/platform_helper.rb
@@ -1,11 +1,11 @@
 def mac?
-  Config::CONFIG['target_os'] =~ /darwin/i
+  RbConfig::CONFIG['target_os'] =~ /darwin/i
 end
 
 def linux?
-  Config::CONFIG['target_os'] =~ /linux/i
+  RbConfig::CONFIG['target_os'] =~ /linux/i
 end
 
 def windows?
-  Config::CONFIG['target_os'] =~ /mswin|mingw/i
+  RbConfig::CONFIG['target_os'] =~ /mswin|mingw/i
 end


### PR DESCRIPTION
Fixed multiple warnings on ruby-head looked like

``` sh
guard/spec/guard/listener_spec.rb:7: Use RbConfig instead of obsolete and deprecated Config.
```

Tests passed on ruby-head, 1.9.2, 1.8.7.
