### PR TITLE
Errors should not be swallowed

### DIFF
--- a/lib/guard.rb
+++ b/lib/guard.rb
@@ -59,11 +59,13 @@ module Guard
     # fire it if his work leads to a system failure
     def supervised_task(guard, task_to_supervise, *args)
       guard.send(task_to_supervise, *args)
-    rescue Exception
-      UI.error("#{guard.class.name} guard failed to achieve its <#{task_to_supervise.to_s}> command: #{$!}")
+    rescue Exception => err
+      UI.error("#{guard.class.name} guard failed to achieve its <#{task_to_supervise.to_s}> command: #{err}")
+      warn "#{err.class}: #{err.message}"
+      warn err.backtrace.join("\n")
       guards.delete guard
       UI.info("Guard #{guard.class.name} has just been fired")
-      return $!
+      return err
     end
 
     def run


### PR DESCRIPTION
If a task for a guard throws an exception, the error is swallowed. This is fine, except that if you're developing a guard, all you get is an error message without an idea of where it occurred, which is not very helpful. This change prints the exception and its backtrace to the console before continuing.

One note about this is that I didn't know whether to print to stderr or use UI.error. I don't really know what the point of the UI module is -- since it resets colors, one would think that it prints colored messages also, but it doesn't do that, so I don't exactly see why it's being used. Feel free to change it to UI.error if that's what you really want, though.
