### PR TITLE
Make home Guardfile hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Pull request [#84](https://github.com/guard/guard/pull/84): Use RbConfig instead of obsolete and deprecated Config. ([@etehtsea][])
 - Pull request [#80](https://github.com/guard/guard/pull/80): Watching dotfile (hidden files under unix). (reported by [@chrisberkhout][], fixed by [@yannlugrin][])
 - Clear the terminal on start when the `:clear` option is given. ([@rymai][])
+- Rename home directory Guardfile to `.Guardfile`. ([@tpope][])
 
 ## 0.4.2 - June 7, 2011
 
@@ -179,6 +180,7 @@
 [@thibaudgg]: https://github.com/thibaudgg
 [@thierryhenrio]: https://github.com/thierryhenrio
 [@tinogomes]: https://github.com/tinogomes
+[@tpope]: https://github.com/tpope
 [@veged]: https://github.com/veged
 [@wereHamster]: https://github.com/wereHamster
 [@yannlugrin]: https://github.com/yannlugrin

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Generate an empty Guardfile with:
 $ guard init
 ```
 
-You may optionally place this Guardfile in your home directory to use it across multiple projects.
+You may optionally place a .Guardfile in your home directory to use it across multiple projects.
 
 Add the guards you need to your Guardfile (see the existing guards below).
 
@@ -120,7 +120,7 @@ or if you use Bundler, to run the Guard executable specific to your bundle:
 $ bundle exec guard [start]
 ```
 
-Guard will look for a Guardfile in your current directory. If it does not find one, it will look in your `$HOME` directory for one.
+Guard will look for a Guardfile in your current directory. If it does not find one, it will look in your `$HOME` directory for a .Guardfile.
 
 Command line options
 --------------------

--- a/lib/guard/dsl.rb
+++ b/lib/guard/dsl.rb
@@ -84,7 +84,7 @@ module Guard
       end
 
       def home_guardfile_path
-        File.expand_path(File.join("~", "Guardfile"))
+        File.expand_path(File.join("~", ".Guardfile"))
       end
 
     end

--- a/spec/guard/dsl_spec.rb
+++ b/spec/guard/dsl_spec.rb
@@ -4,7 +4,7 @@ describe Guard::Dsl do
   subject { described_class }
   before(:each) do
     @local_guardfile_path = File.join(Dir.pwd, 'Guardfile')
-    @home_guardfile_path  = File.expand_path(File.join("~", "Guardfile"))
+    @home_guardfile_path  = File.expand_path(File.join("~", ".Guardfile"))
     ::Guard.stub!(:options).and_return(:debug => true)
   end
 
@@ -129,7 +129,7 @@ describe Guard::Dsl do
 
   describe ".guardfile_default_path" do
     let(:local_path) { File.join(Dir.pwd, 'Guardfile') }
-    let(:user_path) { File.expand_path(File.join("~", 'Guardfile')) }
+    let(:user_path) { File.expand_path(File.join("~", '.Guardfile')) }
 
     before do
       File.stub(:exist? => false)


### PR DESCRIPTION
It's rather un-UNIXy to put a non-hidden config file in the home directory. This patch makes it hidden. I can look into making it backwards compatible if you deem it appropriate, but I've already convinced the original contributors who originally added the home config file so I don't think it's a big deal.
