### PR TITLE
Option to also use growl_notify gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ require 'rbconfig'
 
 if RbConfig::CONFIG['target_os'] =~ /darwin/i
   gem 'rb-fsevent', '>= 0.4.0', :require => false
-  gem 'growl',      '~> 1.0.3', :require => false
+  gem 'growl_notify', :require => false
 end
 if RbConfig::CONFIG['target_os'] =~ /linux/i
   gem 'rb-inotify', '>= 0.8.5', :require => false

--- a/README.md
+++ b/README.md
@@ -50,23 +50,18 @@ Install the rb-fsevent gem for [FSEvent](http://en.wikipedia.org/wiki/FSEvents) 
 $ gem install rb-fsevent
 ```
 
-Install either the growl_notify or the Growl gem if you want notification support:
+Install the growl_notify gem if you want notification support:
 
 ``` bash
 $ gem install growl_notify
-$ # or
-$ gem install growl
 ```
 
-And add them to your Gemfile:
+And add it to your Gemfile:
 
 ``` ruby
 gem 'rb-fsevent'
-gem 'growl'
+gem 'growl_notify'
 ```
-
-growl_notify uses AppleScript, the suggested method for interfacing with Growl,
-rather than the `growlnotify` command to display messages.
 
 ### On Linux
 

--- a/lib/guard/notifier.rb
+++ b/lib/guard/notifier.rb
@@ -47,18 +47,10 @@ module Guard
     def self.notify_mac(title, message, image, options)
       require_growl # need for guard-rspec formatter that is called out of guard scope
 
-      default_options = { :title => title, :icon => image_path(image), :name => APPLICATION_NAME }
-      default_options.merge!(options)
+      options = { :description => message, :title => title, :icon => image_path(image), :application_name => APPLICATION_NAME }.merge(options)
+      options.delete(:name)
 
-      if defined?(GrowlNotify)
-        default_options[:description] = message
-        default_options[:application_name] = APPLICATION_NAME
-        default_options.delete(:name)
-
-        GrowlNotify.send_notification(default_options) if enabled?
-      else
-        Growl.notify message, default_options.merge(options) if enabled?
-      end
+      GrowlNotify.send_notification(options) if enabled?
     end
 
     def self.notify_linux(title, message, image, options)
@@ -102,21 +94,17 @@ module Guard
     end
 
     def self.require_growl
-      begin
-        require 'growl_notify'
+      require 'growl_notify'
 
-        if GrowlNotify.application_name != APPLICATION_NAME
-          GrowlNotify.config do |c|
-            c.notifications = c.default_notifications = [ APPLICATION_NAME ]
-            c.application_name = c.notifications.first
-          end
+      if GrowlNotify.application_name != APPLICATION_NAME
+        GrowlNotify.config do |c|
+          c.notifications = c.default_notifications = [ APPLICATION_NAME ]
+          c.application_name = c.notifications.first
         end
-      rescue LoadError
-        require 'growl'
       end
     rescue LoadError
       turn_off
-      UI.info "Please install growl or growl_notify gem for Mac OS X notification support and add it to your Gemfile"
+      UI.info "Please install growl_notify gem for Mac OS X notification support and add it to your Gemfile"
     end
 
     def self.require_libnotify

--- a/spec/guard/notifier_spec.rb
+++ b/spec/guard/notifier_spec.rb
@@ -39,19 +39,9 @@ describe Guard::Notifier do
         end
       end
 
-      context "with the Growl library available" do
-        it "loads the library and enables the notifications" do
-          subject.should_receive(:require).with('growl_notify').and_raise LoadError
-          subject.should_receive(:require).with('growl').and_return true
-          subject.turn_on
-          subject.should be_enabled
-        end
-      end
-
-      context "without the Growl library available" do
+      context "without the GrowlNofity library available" do
         it "disables the notifications" do
           subject.should_receive(:require).with('growl_notify').and_raise LoadError
-          subject.should_receive(:require).with('growl').and_raise LoadError
           subject.turn_on
           subject.should_not be_enabled
         end
@@ -110,51 +100,6 @@ describe Guard::Notifier do
       before do
         RbConfig::CONFIG.should_receive(:[]).with('target_os').and_return 'darwin'
         subject.stub(:require_growl)
-      end
-
-      context 'with growl gem' do
-        before do
-          Object.send(:remove_const, :Growl) if defined?(Growl)
-          Growl = Object.new
-        end
-
-        after do
-          Object.send(:remove_const, :Growl)
-        end
-
-        it "passes the notification to Growl" do
-          Growl.should_receive(:notify).with("great",
-            :title => "Guard",
-            :icon  => Pathname.new(File.dirname(__FILE__)).join('../../images/success.png').to_s,
-            :name  => "Guard"
-          )
-          subject.notify 'great', :title => 'Guard'
-        end
-
-        it "don't passes the notification to Growl if library is not available" do
-          Growl.should_not_receive(:notify)
-          subject.should_receive(:enabled?).and_return(true, false)
-          subject.notify 'great', :title => 'Guard'
-        end
-
-        it "allows additional notification options" do
-          Growl.should_receive(:notify).with("great",
-            :title => "Guard",
-            :icon  => Pathname.new(File.dirname(__FILE__)).join('../../images/success.png').to_s,
-            :name  => "Guard",
-            :priority => 1
-          )
-          subject.notify 'great', :title => 'Guard', :priority => 1
-        end
-
-        it "allows to overwrite a default notification option" do
-          Growl.should_receive(:notify).with("great",
-            :title => "Guard",
-            :icon  => Pathname.new(File.dirname(__FILE__)).join('../../images/success.png').to_s,
-            :name  => "Guard-Cucumber"
-          )
-          subject.notify 'great', :title => 'Guard', :name => "Guard-Cucumber"
-        end
       end
 
       context 'with growl_notify gem' do


### PR DESCRIPTION
[`growl_notify`](http://github.com/jetviper21/growl_notify) is a gem that uses AppleScript, the recommended approach, rather than the `growlnotify` CLI app, which is what the `growl` gem uses, to make Growl notifications. This change checks for `growl_notify` and then `growl` and uses the first one found. I've been running this fork for a few days with no problems, but I think it needs wider testing, since `growl_notify` is still pretty new.
