### PR TITLE
Fix undefined method `empty?' for nil:NilClass error

### DIFF
--- a/lib/guard/dsl.rb
+++ b/lib/guard/dsl.rb
@@ -9,7 +9,7 @@ module Guard
         @@options = options.dup
         instance_eval_guardfile(fetch_guardfile_contents)
 
-        UI.error "No guards found in Guardfile, please add at least one." if ::Guard.guards.empty?
+        UI.error "No guards found in Guardfile, please add at least one." if ::Guard.guards.nil? || ::Guard.guards.empty?
       end
 
       def revaluate_guardfile


### PR DESCRIPTION
When I run 'guard -T' I get:

```
/home/bronson/.rvm/gems/ruby-1.9.2-p180/gems/guard-0.5.0/lib/guard/dsl.rb:12:in `evaluate_guardfile':
undefined method `empty?' for nil:NilClass (NoMethodError)
from /home/bronson/.rvm/gems/ruby-1.9.2-p180/gems/guard-0.5.0/lib/guard/cli.rb:42:in `show'
from /home/bronson/.rvm/gems/ruby-1.9.2-p180/gems/thor-0.14.6/lib/thor/task.rb:22:in `run'
from /home/bronson/.rvm/gems/ruby-1.9.2-p180/gems/thor-0.14.6/lib/thor/invocation.rb:118:in `invoke_task'
from /home/bronson/.rvm/gems/ruby-1.9.2-p180/gems/thor-0.14.6/lib/thor.rb:263:in `dispatch'
from /home/bronson/.rvm/gems/ruby-1.9.2-p180/gems/thor-0.14.6/lib/thor/base.rb:389:in `start'
from /home/bronson/.rvm/gems/ruby-1.9.2-p180/gems/guard-0.5.0/bin/guard:6:in `<top (required)>'
from /home/bronson/.rvm/gems/ruby-1.9.2-p180/bin/guard:19:in `load'
from /home/bronson/.rvm/gems/ruby-1.9.2-p180/bin/guard:19:in `<main>'
```

Trivial fix makes Guard print "no guards in guardfile" instead of crashing.
