### PR TITLE
show error when loading guard fails (solves problem when you have no clue

### DIFF
--- a/lib/guard.rb
+++ b/lib/guard.rb
@@ -101,8 +101,9 @@ module Guard
         else
           UI.error "Could not find class Guard::#{const_name.capitalize}"
         end
-      rescue LoadError
+      rescue LoadError => loadError
         UI.error "Could not load 'guard/#{name.downcase}' or find class Guard::#{const_name.capitalize}"
+        UI.error loadError.to_s
       end
     end
 


### PR DESCRIPTION
Please consider showing actual error message when loading a guard fails.
In many cases general one-liner message is pretty much useless.
