### PR TITLE
Fix an unmatched quote in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ You can list the defined groups and guards for the current Guardfile from the co
   shell
 Group backend:
   bundler
-  rspec: cli => "--color --format doc'
+  rspec: cli => "--color --format doc"
 Group frontend:
   coffeescript: output => "public/javascripts/compiled"
   livereload


### PR DESCRIPTION
It's a small thing. But makes it easier to read since code highlighting in github gets confused. Just thought Id let you know. No reason you need to pull this change and give me credit, just change it next time you edit the readme.
