### PR TITLE
Polling#watch_change should use listener directory, not Dir.pwd

### DIFF
--- a/lib/guard/listeners/polling.rb
+++ b/lib/guard/listeners/polling.rb
@@ -22,7 +22,7 @@ module Guard
     def watch_change
       until @stop
         start = Time.now.to_f
-        files = modified_files([Dir.pwd], :all => true)
+        files = modified_files([@directory], :all => true)
         @callback.call(files) unless files.empty?
         nap_time = @latency - (Time.now.to_f - start)
         sleep(nap_time) if nap_time > 0


### PR DESCRIPTION
The polling listener is not respecting the directory set for it. It was hardcoded in watch_change to the current working dir.
