### PR TITLE
Fix re-evaluating Guardfile

### DIFF
--- a/lib/guard/dsl.rb
+++ b/lib/guard/dsl.rb
@@ -14,6 +14,7 @@ module Guard
 
       def reevaluate_guardfile
         ::Guard.guards.clear
+        @@options.delete(:guardfile_contents)
         Dsl.evaluate_guardfile(@@options)
         msg = "Guardfile has been re-evaluated."
         UI.info(msg)


### PR DESCRIPTION
I noticed that the re-evaluation doesn't read the Guardfile. It just took the contents from the Guardfile before.
The other issue I encountered was that the changing the Guardfile twice didn't trigger the reevaluate_guardfile method.

Deleting the old contents before triggering evaluate_guardfile solved both issues:

```
@@options.delete(:guardfile_contents)
```
