### PR TITLE
Fix over-utilization of CPU in Interactor

### DIFF
--- a/lib/guard/interactor.rb
+++ b/lib/guard/interactor.rb
@@ -45,6 +45,7 @@ module Guard
                   ::Guard.run_all
               end
             end
+            sleep 0.1
           rescue LockException
             lock
           rescue UnlockException


### PR DESCRIPTION
The new Interactor was taking way more CPU than it should, simply because the loop in the thread was so tight that not even test UIs could update quickly (the very very slow progress bar while using Hydra was my hint something was up). This adds a `sleep 0.1` to the Interactor thread, the same sleep time as the Listener's thread, in order to prevent Guard itself from hijacking a CPU to itself while running tests.
