### PR TITLE
Growl Notify Api Update

### DIFF
--- a/lib/guard/notifier.rb
+++ b/lib/guard/notifier.rb
@@ -181,6 +181,9 @@ module Guard
         end
       rescue LoadError
         require 'growl'
+      rescue ::GrowlNotify::GrowlNotFound
+        turn_off
+        UI.info "Please install Growl from http://growl.info"
       end
     rescue LoadError
       turn_off

--- a/spec/guard/notifier_spec.rb
+++ b/spec/guard/notifier_spec.rb
@@ -21,9 +21,19 @@ describe Guard::Notifier do
 
       context "with the GrowlNotify library available" do
         before do
-          module ::GrowlNotify
+          class ::GrowlNotify
+            class GrowlNotFound < Exception; end
             def self.config ; end
           end
+        end
+        
+        it "should respond properly to a GrowlNotify exception" do
+          ::GrowlNotify.should_receive(:config).and_raise ::GrowlNotify::GrowlNotFound
+          ::GrowlNotify.should_receive(:application_name).and_return ''
+          ::Guard::UI.should_receive(:info)
+          described_class.should_receive(:require).with('growl_notify').and_return true
+          described_class.turn_on
+          described_class.should_not be_enabled
         end
 
         it "loads the library and enables the notifications" do


### PR DESCRIPTION
updated the growl notify code to gracefuly fail if growl is not installed - this is new in growl_notify-0.0.3
