### PR TITLE
any return

### DIFF
--- a/lib/guard/watcher.rb
+++ b/lib/guard/watcher.rb
@@ -40,6 +40,7 @@ module Guard
     # @param [Guard::Guard] guard the guard which watchers are used
     # @param [Array<String>] files the changed files
     # @return [Array<Object>] the matched watcher response
+    #
     def self.match_files(guard, files)
       guard.watchers.inject([]) do |paths, watcher|
         files.each do |file|
@@ -57,7 +58,7 @@ module Guard
           end
         end
         
-        watcher.any_return ? paths : paths.flatten.map{|p| p.to_s}
+        watcher.any_return ? paths : paths.flatten.map{ |p| p.to_s }
       end
     end
 

--- a/spec/guard/watcher_spec.rb
+++ b/spec/guard/watcher_spec.rb
@@ -147,7 +147,7 @@ describe Guard::Watcher do
          @guard.watchers = [
            described_class.new(%r{lib/(.*)\.rb},   lambda { |m| "spec/#{m[1]}_spec.rb" }),
            described_class.new(/addition(.*)\.rb/, lambda { |m| 1 + 1 }),
-           described_class.new('hash.rb',          lambda { Hash[:foo, 'bar'] }),
+           described_class.new('hash.rb',          lambda { |m| Hash[:foo, 'bar'] }),
            described_class.new(/array(.*)\.rb/,    lambda { |m| ['foo', 'bar'] }),
            described_class.new(/blank(.*)\.rb/,    lambda { |m| '' }),
            described_class.new(/uptime(.*)\.rb/,   lambda { |m| `uptime > /dev/null` })
@@ -184,7 +184,7 @@ describe Guard::Watcher do
         @guard.watchers = [
           described_class.new(%r{lib/(.*)\.rb},   lambda { |m| "spec/#{m[1]}_spec.rb" }, true),
           described_class.new(/addition(.*)\.rb/, lambda { |m| (1 + 1).to_s + m[0] }, true),
-          described_class.new('hash.rb',          lambda {|m| Hash[:foo, 'bar', :file_name, m[0]] }, true),
+          described_class.new('hash.rb',          lambda { |m| Hash[:foo, 'bar', :file_name, m[0]] }, true),
           described_class.new(/array(.*)\.rb/,    lambda { |m| ['foo', 'bar', m[0]] }, true),
           described_class.new(/blank(.*)\.rb/,    lambda { |m| '' }, true),
           described_class.new(/uptime(.*)\.rb/,   lambda { |m| `uptime > /dev/null` }, true)
@@ -220,10 +220,10 @@ describe Guard::Watcher do
        before(:all) { @guard.watchers = [described_class.new('evil.rb', lambda { raise "EVIL" })] }
 
        it "displays the error and backtrace" do
-         Guard::UI.should_receive(:error) { |msg|
+         Guard::UI.should_receive(:error) do |msg|
            msg.should include("Problem with watch action!")
            msg.should include("EVIL")
-         }
+         end
 
          described_class.match_files(@guard, ['evil.rb'])
        end


### PR DESCRIPTION
Hey, 

I wanted to do something like this 

``` ruby
watch(%r{^tmp/facbingham/.+\.txt}){|m| {:file_name => m, :other_param => "CAI"}}
```

but I had to settle for

``` ruby
watch(%r{^tmp/facbingham/.+\.txt}){|m| [521, m, "CAI"]}
```

and then in my ftp_guard.rb

``` ruby
def run_on_change(paths)
    new_paths = []
    new_paths << {:facility_id => paths[0], :file_name => paths[1], :vendor=> paths[2]}
end
```

and still you can only return strings into these values. 
So this branch you can return anything with a block.
Maybe I am missing something. 
Thanks for making such a great gem! 
