### PR TITLE
0.8.5 Broken: Fix `guard init` path to Guardfile template

### DIFF
--- a/lib/guard.rb
+++ b/lib/guard.rb
@@ -32,7 +32,7 @@ module Guard
       else
         if !File.exist?('Guardfile')
           ::Guard::UI.info "Writing new Guardfile to #{ Dir.pwd }/Guardfile"
-          FileUtils.cp(File.expand_path('../templates/Guardfile', __FILE__), 'Guardfile')
+          FileUtils.cp(File.expand_path('../guard/templates/Guardfile', __FILE__), 'Guardfile')
         else
           ::Guard::UI.error "Guardfile already exists at #{ Dir.pwd }/Guardfile"
           exit 1


### PR DESCRIPTION
Between 0.8.4 and 0.8.5, the file that calls the `guard init` task changed, but the path to the template Guardfile was not adjusted accordingly. This results in an error when doing `guard init` using version 0.8.5 of this gem.

This pull request makes the small tweak necessary to point to the correct path of the Guardfile.
