### PR TITLE
Fix terminal status after interrupting the Readline interactor

### DIFF
--- a/lib/guard.rb
+++ b/lib/guard.rb
@@ -193,6 +193,7 @@ module Guard
         run_supervised_task(guard, :stop)
       end
 
+      interactor.stop if interactor
       listener.stop
       abort
     end

--- a/lib/guard/cli.rb
+++ b/lib/guard/cli.rb
@@ -72,6 +72,8 @@ module Guard
     #
     def start
       ::Guard.start(options)
+    rescue Interrupt
+      ::Guard.stop
     end
 
     desc 'list', 'Lists guards that can be used with init'

--- a/lib/guard/interactors/readline.rb
+++ b/lib/guard/interactors/readline.rb
@@ -28,6 +28,20 @@ module Guard
       end
     end
 
+    # Start the interactor.
+    #
+    def start
+      store_terminal_settings
+      super
+    end
+
+    # Stop the interactor.
+    #
+    def stop
+      super
+      restore_terminal_settings
+    end
+
     # Read a line from stdin with Readline.
     #
     def read_line
@@ -68,5 +82,19 @@ module Guard
       ::Guard.listener.paused? ? 'p> ' : '> '
     end
 
+    private
+
+    # Stores the terminal settings so we can resore them
+    # when stopping.
+    #
+    def store_terminal_settings
+      @stty_save = `stty -g`.chomp
+    end
+
+    # Restore terminal settings
+    #
+    def restore_terminal_settings
+      system('stty', @stty_save)
+    end
   end
 end

--- a/spec/guard/cli_spec.rb
+++ b/spec/guard/cli_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+require 'guard/cli'
+
+describe Guard::CLI do
+  let(:guard) { Guard }
+
+  describe '#start' do
+    it 'should rescue from an interrupt signal and close nicely' do
+      guard.should_receive(:start).and_raise(Interrupt)
+      guard.should_receive(:stop)
+
+      subject.start
+    end
+  end
+
+end

--- a/spec/guard/interactors/readline_spec.rb
+++ b/spec/guard/interactors/readline_spec.rb
@@ -15,6 +15,22 @@ describe Guard::ReadlineInteractor do
     end
   end
 
+  describe '#start' do
+    it 'stores the terminal settings' do
+      subject.should_receive(:store_terminal_settings)
+      subject.start
+    end
+  end
+
+  describe '#stop' do
+    before { Thread.stub(:current).and_return(nil) }
+
+    it 'restores the terminal settings' do
+      subject.should_receive(:restore_terminal_settings)
+      subject.stop
+    end
+  end
+
   describe '#readline' do
     before do
       Guard.listener = mock('listener')


### PR DESCRIPTION
Hey there,

I have been using the new 0.9.1 for a few days now I noticed that it was messing up my terminal when I stopped Guard using a signal such as CTRL+C.

I looked into it today and I found out (after reading a bit about the Readline gem) that the ruby interpreter doesn't restore the status of the terminal if it was interrupted.

Now with the new 0.9.2 and the separation of the interactors, it was even easier to implement a fix :).

One good side-effect for this patch is the better handing for the INT signal in general. Now Guard closes nicely when it's interrupted and will inform all guards to stop.

All the additions I made come with tests for the important parts.

**Update** I believe this will also fix #200.
