### PR TITLE
Fix specs on rubinius

### DIFF
--- a/spec/guard/interactors/readline_spec.rb
+++ b/spec/guard/interactors/readline_spec.rb
@@ -23,7 +23,7 @@ describe Guard::ReadlineInteractor do
   end
 
   describe '#stop' do
-    before { Thread.stub(:current).and_return(nil) }
+    before { subject.instance_variable_set(:@thread, Thread.current) }
 
     it 'restores the terminal settings' do
       subject.should_receive(:restore_terminal_settings)


### PR DESCRIPTION
Hello,

My [last commit](https://github.com/guard/guard/commit/d3569beed64a90401578ac7ed6c3685eb290424d) broke the specs of the Readline interactor on rubinius.
Guard still works, only a few specs on rubinius were broken. So it might not be necessarily to release a new patch.
The problem was that rubunius couldn't stub the `Thread.new` method, it might be a bug in
either rspec or rubunius.

You can check that it works now from: http://travis-ci.org/#!/Maher4Ever/guard
