### PR TITLE
Use ENV variable to store Notifier notifications

### DIFF
--- a/lib/guard/dsl.rb
+++ b/lib/guard/dsl.rb
@@ -109,7 +109,7 @@ module Guard
       def reevaluate_guardfile
         ::Guard.guards.clear
         ::Guard.reset_groups
-        ::Guard::Notifier.notifications.clear
+        ::Guard::Notifier.clear_notifications
         @@options.delete(:guardfile_contents)
         Dsl.evaluate_guardfile(@@options)
         msg = 'Guardfile has been re-evaluated.'

--- a/lib/guard/notifier.rb
+++ b/lib/guard/notifier.rb
@@ -1,3 +1,5 @@
+require 'yaml'
+
 require 'rbconfig'
 require 'pathname'
 require 'guard/ui'
@@ -53,7 +55,7 @@ module Guard
     # @return [Hash] the notifications
     #
     def notifications
-      @notifications ||= []
+      ENV['GUARD_NOTIFICATIONS'] ? YAML::load(ENV['GUARD_NOTIFICATIONS']) : []
     end
 
     # Set the available notifications.
@@ -61,7 +63,13 @@ module Guard
     # @param [Array<Hash>] notifications the notifications
     #
     def notifications=(notifications)
-      @notifications = notifications
+      ENV['GUARD_NOTIFICATIONS'] = YAML::dump(notifications)
+    end
+
+    # Clear available notifications.
+    #
+    def clear_notifications
+      ENV['GUARD_NOTIFICATIONS'] = nil
     end
 
     # Turn notifications on. If no notifications are defined
@@ -107,7 +115,7 @@ module Guard
       return turn_off if name == :off
 
       if NOTIFIERS.has_key?(name) && NOTIFIERS[name].available?(silent)
-        notifications << { :name => name, :options => options }
+        self.notifications = notifications << { :name => name, :options => options }
         true
       else
         false


### PR DESCRIPTION
Guard::RSpec formatter is call outside guard so notifications variable
is always empty (if not set with an ENV variable) and no notifications
are fired.

Sounds good to you?
