### PR TITLE
Fix exit-status codes for Guard

### DIFF
--- a/lib/guard.rb
+++ b/lib/guard.rb
@@ -214,7 +214,6 @@ module Guard
 
       interactor.stop if interactor
       listener.stop
-      abort
     end
 
     # Reload all Guards currently enabled.

--- a/lib/guard/cli.rb
+++ b/lib/guard/cli.rb
@@ -74,6 +74,7 @@ module Guard
       ::Guard.start(options)
     rescue Interrupt
       ::Guard.stop
+      abort
     end
 
     desc 'list', 'Lists guards that can be used with init'

--- a/lib/guard/interactor.rb
+++ b/lib/guard/interactor.rb
@@ -123,6 +123,7 @@ module Guard
         help
       when :stop
         ::Guard.stop
+        exit
       when :pause
         ::Guard.pause
       when :reload

--- a/spec/guard/cli_spec.rb
+++ b/spec/guard/cli_spec.rb
@@ -5,11 +5,27 @@ describe Guard::CLI do
   let(:guard) { Guard }
 
   describe '#start' do
-    it 'should rescue from an interrupt signal and close nicely' do
-      guard.should_receive(:start).and_raise(Interrupt)
-      guard.should_receive(:stop)
+    context 'with an interrupt signal' do
+      before do
+        guard.should_receive(:start).and_raise(Interrupt)
+        guard.stub(:stop)
+      end
 
-      subject.start
+      it 'exits nicely' do
+        guard.should_receive(:stop)
+        subject.stub(:abort)
+
+        subject.start
+      end
+
+      it 'exits with failure status code' do
+        begin
+          subject.start
+          raise 'Guard did not abort!'
+        rescue SystemExit => e
+          e.status.should_not eq(0)
+        end
+      end
     end
   end
 

--- a/spec/guard/interactor_spec.rb
+++ b/spec/guard/interactor_spec.rb
@@ -40,10 +40,16 @@ describe Guard::Interactor do
       subject.process_input 'help'
     end
 
-    it 'stops Guard on stop action' do
+    it 'stops Guard on stop action and exit' do
       subject.should_receive(:extract_scopes_and_action).with('stop').and_return [{ }, :stop]
       ::Guard.should_receive(:stop)
-      subject.process_input 'stop'
+
+      begin
+        subject.process_input 'stop'
+        raise 'Guard did not exit!'
+      rescue SystemExit => e
+        e.status.should eq(0)
+      end
     end
 
     it 'pauses Guard on pause action' do


### PR DESCRIPTION
While using Guard I always noticed that it exits with status code "1" even when using the interactor to stop it  (My terminal shows failure status codes).
It would be nice to let Guard exit with the right status codes because it is a tool used by a lot of developers.

I've changed the way Guard exits in this commit. Guard doesn't exit the program no more when calling `Guard.stop`. This has the advantage of being able to use `Guard.stop` programmatically knowing it won't kill the process.

I felt that the interactor should be the one to exit Guard's process, so now it will call `Kernel::exit` after it stops all running guards.

When there is an interrupt, Guard will still stop all guards, but now it will use `Kernel::abort` to return a failure status-code.

The commits will apply nicely and the specs pass: http://travis-ci.org/#!/Maher4Ever/guard
