### PR TITLE
Fixes a weird error when running programmatically

### DIFF
--- a/lib/vendor/darwin/lib/rb-fsevent/fsevent.rb
+++ b/lib/vendor/darwin/lib/rb-fsevent/fsevent.rb
@@ -7,7 +7,7 @@ class FSEvent
     END
     class_eval <<-END
       def watcher_path
-        "#{File.join(FSEvent.root_path, 'bin', 'fsevent_watch_guard')}"
+        "#{File.join(FSEvent.root_path, 'bin', 'fsevent_watch_guard_guard')}"
       end
     END
   end


### PR DESCRIPTION
I'm not sure why I only ran into this error occasionally, but it looks like the reference to the file was wrong and I was getting the following error:

.../gems/guard-1.0.0/lib/guard/interactor.rb:85: command not found: .../gems/guard-1.0.0/bin/fsevent_watch_guard  ~/Workspace/project

The actual filename is bin/fsevent_watch_guard_guard

I figured this would be less invasive than renaming the file and it should only affect osx users
