### PR TITLE
Add support for Emacs notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ group :development do
 end
 ```
 
+#### Emacs
+
+* Runs on any platform with Emacs + emacsclient (http://www.emacswiki.org/emacs/EmacsClient)
+
 Add Guard plugins
 -----------------
 
@@ -612,6 +616,7 @@ notification :gntp, :sticky => true, :host => '192.168.1.5', :password => 'secre
 notification :growl_notify, :sticky => true, :priority => 0
 notification :libnotify, :timeout => 5, :transient => true, :append => false, :urgency => :critical
 notification :notifu, :time => 5, :nosound => true, :xp => true
+notification :emacs
 ```
 
 It's possible to use more than one notifier. This allows you to configure different notifiers for different OS if your

--- a/lib/guard/notifier.rb
+++ b/lib/guard/notifier.rb
@@ -9,6 +9,7 @@ require 'guard/notifiers/growl_notify'
 require 'guard/notifiers/libnotify'
 require 'guard/notifiers/notifysend'
 require 'guard/notifiers/rb_notifu'
+require 'guard/notifiers/emacs'
 
 module Guard
 
@@ -49,7 +50,8 @@ module Guard
         :growl_notify => ::Guard::Notifier::GrowlNotify,
         :libnotify    => ::Guard::Notifier::Libnotify,
         :notifysend   => ::Guard::Notifier::NotifySend,
-        :notifu       => ::Guard::Notifier::Notifu
+        :notifu       => ::Guard::Notifier::Notifu,
+        :emacs        => ::Guard::Notifier::Emacs
     }
 
     # Get the available notifications.
@@ -153,7 +155,7 @@ module Guard
     # is available.
     #
     def auto_detect_notification
-      available = [:growl_notify, :gntp, :growl, :libnotify, :notifysend, :notifu].any? { |notifier| add_notification(notifier, { }, true) }
+      available = [:growl_notify, :gntp, :growl, :libnotify, :notifysend, :notifu, :emacs].any? { |notifier| add_notification(notifier, { }, true) }
       ::Guard::UI.info('Guard could not detect any of the supported notification libraries.') unless available
     end
 

--- a/lib/guard/notifiers/emacs.rb
+++ b/lib/guard/notifiers/emacs.rb
@@ -1,0 +1,60 @@
+require 'rbconfig'
+
+module Guard
+  module Notifier
+
+    DEFAULTS = {
+      :client => 'emacsclient',
+      :success => 'ForestGreen',
+      :failed => 'Firebrick',
+      :default => 'Black',
+    }
+
+    # @example Add the `:emacs` notifier to your `Guardfile`
+    #   notification :emacs
+    #
+    module Emacs
+      extend self
+
+      # Test if Emacs with running server is available.
+      #
+      # @param [Boolean] silent true if no error messages should be shown
+      # @return [Boolean] the availability status
+      #
+      def available?(silent = false)
+        result = `#{DEFAULTS[:client]} --eval '1' 2> /dev/null || echo 0`
+
+        if result.chomp! == "1"
+          true
+        else
+          false
+        end
+      end
+
+      # Show a system notification.
+      #
+      # @param [String] type the notification type. Either 'success', 'pending', 'failed' or 'notify'
+      # @param [String] title the notification title
+      # @param [String] message the notification message body
+      # @param [String] image the path to the notification image
+      # @param [Hash] options additional notification library options
+      # @option options [Boolean] sticky make the notification sticky
+      # @option options [String, Integer] priority specify an int or named key (default is 0)
+      #
+      def notify(type, title, message, image, options = { })
+        system(%(#{DEFAULTS[:client]} --eval "(set-face-background 'modeline \\"#{emacs_color(type)}\\")"))
+      end
+
+      def emacs_color(type)
+        case type
+            when 'success'
+              DEFAULTS[:success]
+            when 'failed'
+              DEFAULTS[:failed]
+            else
+              DEFAULTS[:default]
+        end
+      end
+    end
+  end
+end

--- a/spec/guard/notifier_spec.rb
+++ b/spec/guard/notifier_spec.rb
@@ -37,6 +37,7 @@ describe Guard::Notifier do
           Guard::Notifier.should_receive(:add_notification).with(:libnotify, { }, true).and_return false
           Guard::Notifier.should_receive(:add_notification).with(:notifysend, { }, true).and_return false
           Guard::Notifier.should_receive(:add_notification).with(:notifu, { }, true).and_return false
+          Guard::Notifier.should_receive(:add_notification).with(:emacs, { }, true).and_return false
           Guard::Notifier.turn_on
         end
 

--- a/spec/guard/notifiers/emacs_spec.rb
+++ b/spec/guard/notifiers/emacs_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe Guard::Notifier::Emacs do
+  before(:all) { Object.send(:remove_const, :Emacs) if defined?(::Emacs) }
+
+  before do
+    class ::Emacs
+      def self.show(options) end
+    end
+  end
+
+  after { Object.send(:remove_const, :Emacs) if defined?(::Emacs) }
+
+  describe '.notify' do
+    it 'should set correct modeline color using emacsclient' do
+      subject.should_receive(:system).with do |command|
+        command.should include("emacsclient")
+        command.should include("(set-face-background 'modeline \\\"ForestGreen\\\")")
+      end
+
+      subject.notify('success', 'any title', 'any message', 'any image', { })
+    end
+  end
+end


### PR DESCRIPTION
change modeline color according to notification type using emacsclient.

One has to run Emacs with server mode enabled so that emacsclient can
send notifications to it.
- http://www.gnu.org/software/emacs/manual/html_node/emacs/Emacs-Server.html
- http://www.emacswiki.org/emacs/EmacsClient
