### PR TITLE
Remove file:// prefix from image path for GNTP

### DIFF
--- a/lib/guard/notifiers/gntp.rb
+++ b/lib/guard/notifiers/gntp.rb
@@ -104,7 +104,7 @@ module Guard
             :name  => type,
             :title => title,
             :text  => message,
-            :icon  => "file://#{ image }"
+            :icon  => image
         }))
       end
 

--- a/spec/guard/notifiers/gntp_spec.rb
+++ b/spec/guard/notifiers/gntp_spec.rb
@@ -87,7 +87,7 @@ describe Guard::Notifier::GNTP do
             :name   => 'success',
             :title  => 'Welcome',
             :text   => 'Welcome to Guard',
-            :icon   => 'file:///tmp/welcome.png'
+            :icon   => '/tmp/welcome.png'
         })
         subject.notify('success', 'Welcome', 'Welcome to Guard', '/tmp/welcome.png', { })
       end
@@ -100,7 +100,7 @@ describe Guard::Notifier::GNTP do
             :name   => 'pending',
             :title  => 'Waiting',
             :text   => 'Waiting for something',
-            :icon   => 'file:///tmp/wait.png'
+            :icon   => '/tmp/wait.png'
         })
         subject.notify('pending', 'Waiting', 'Waiting for something', '/tmp/wait.png', {
             :sticky => true,
@@ -113,7 +113,7 @@ describe Guard::Notifier::GNTP do
             :name   => 'failed',
             :title  => 'Failed',
             :text   => 'Something failed',
-            :icon   => 'file:///tmp/fail.png'
+            :icon   => '/tmp/fail.png'
         })
         subject.notify('failed', 'Failed', 'Something failed', '/tmp/fail.png', {
             :name  => 'custom',


### PR DESCRIPTION
ruby_gtnp supports embedding image data directly in the notification
allowing remote notifications to display an image.

In practice, this change has been tested with Growl for Windows
receiving the notification and it behaves as expected, i.e. the image
appears in the notification.

This also likely resolves issue #231, as that involves Growl (for OSX)
refusing to download the images.
