### PR TITLE
Remove duplicated list of available NOTIFIERS

### DIFF
--- a/lib/guard/notifier.rb
+++ b/lib/guard/notifier.rb
@@ -155,7 +155,7 @@ module Guard
     # is available.
     #
     def auto_detect_notification
-      available = [:growl_notify, :gntp, :growl, :libnotify, :notifysend, :notifu, :emacs].any? { |notifier| add_notification(notifier, { }, true) }
+      available = NOTIFIERS.keys.any? { |notifier| add_notification(notifier, { }, true) }
       ::Guard::UI.info('Guard could not detect any of the supported notification libraries.') unless available
     end
 


### PR DESCRIPTION
Use `NOTIFIERS.keys` instead of the notifiers list
