### PR TITLE
Improve Emacs detection

### DIFF
--- a/lib/guard/notifiers/emacs.rb
+++ b/lib/guard/notifiers/emacs.rb
@@ -25,12 +25,12 @@ module Guard
       # @return [Boolean] the availability status
       #
       def available?(silent = false)
-        result = `#{DEFAULTS[:client]} --eval '1' 2> /dev/null || echo 0`
+        result = `#{DEFAULTS[:client]} --eval '1' 2> /dev/null || echo 'N/A'`
 
-        if result.chomp! == "1"
-          true
-        else
+        if result.chomp! == "N/A"
           false
+        else
+          true
         end
       end
 


### PR DESCRIPTION
for some reason emacsclient sometimes doesn't return result of
evaluation so it's safer to base decision on non-zero exit value.
