### PR TITLE
Allow Terminal Notifier title to be customizable

### DIFF
--- a/lib/guard/notifiers/terminal_notifier.rb
+++ b/lib/guard/notifiers/terminal_notifier.rb
@@ -56,7 +56,7 @@ module Guard
       #
       def notify(type, title, message, image, options = { })
         require 'terminal-notifier-guard'
-        options[:title] = [options[:app_name] || 'Guard', type.downcase.capitalize, title].join ' '
+        options[:title] = title || [options[:app_name] || 'Guard', type.downcase.capitalize].join(' ')
         options.merge!(:type => type.to_sym, :message => message)
         options.delete :app_name if options[:app_name]
         ::TerminalNotifier::Guard.execute(false, options)

--- a/spec/guard/notifiers/terminal_notifier_spec.rb
+++ b/spec/guard/notifiers/terminal_notifier_spec.rb
@@ -29,28 +29,28 @@ describe Guard::Notifier::TerminalNotifier do
     it "should call the notifier." do
       ::TerminalNotifier::Guard.should_receive(:execute).with(
         false,
-        {:title=>"Guard Success any title", :type=>:success, :message=>"any message"}
+        {:title=>"any title", :type=>:success, :message=>"any message"}
       )
       subject.notify('success', 'any title', 'any message', 'any image', { })
     end
 
-    it "should show the type of message in the title" do
+    it "should allow the title to be customized" do
       ::TerminalNotifier::Guard.should_receive(:execute).with(
         false,
-        {:title=>"Guard Error any title", :message => "any message", :type => :error}
+        {:title=>"any title", :message => "any message", :type => :error}
       )
 
       subject.notify('error', 'any title', 'any message', 'any image', { })
     end
 
-    context "with an app name set" do
+    context "without a title set" do
       it "should show the app name in the title" do
         ::TerminalNotifier::Guard.should_receive(:execute).with(
           false,
-          {:title=>"FooBar Success any title", :type=>:success, :message=>"any message"}
+          {:title=>"FooBar Success", :type=>:success, :message=>"any message"}
         )
 
-        subject.notify('success', 'any title', 'any message', 'any image', {:app_name => "FooBar"})
+        subject.notify('success', nil, 'any message', 'any image', {:app_name => "FooBar"})
       end
     end
   end


### PR DESCRIPTION
This pull allows the title of Terminal Notifier-based notifications to be completely customized by the title argument, if it is present. Previously, the title would be forced into a pre-defined format unnecessarily:  "RSpec Success Tests Complete." The success/failure of the operation would always be added, which made for some awkward reading (and dense) notifications.
