### PR TITLE
Hook instead of RC_FILES; Increased verbosity.

### DIFF
--- a/lib/guard/interactor.rb
+++ b/lib/guard/interactor.rb
@@ -16,11 +16,22 @@ module Guard
     require 'guard/commands/pause'
     require 'guard/commands/reload'
     require 'guard/commands/show'
+    GUARD_RC = '~/.guardrc'
+    HISTORY_FILE = '~/.guard_history'
 
     def initialize
-      Pry::RC_FILES.unshift '~/.guardrc'
-      Pry.config.history.file = '~/.guard_history'
-
+      Pry.config.hooks.add_hook :when_started, :load_guard_rc do
+        if File.exist? File.expand_path GUARD_RC
+          load GUARD_RC
+        else
+          example_guard_rc_url = 'https://gist.github.com/da7f4b2f8465a3d75cd4'
+          Pry.output.puts <<-EOT
+- No ~/.guardrc found, so commands will be more verbose.
+(See tersifying example at #{example_guard_rc_url} )
+          EOT
+        end
+      end
+      Pry.config.history.file = HISTORY_FILE
       Pry.config.prompt = [
         proc do |target_self, nest_level, pry|
           "[#{pry.input_array.size}] #{ ::Guard.listener.paused? ? 'pause' : 'guard' }(#{Pry.view_clip(target_self)})#{":#{nest_level}" unless nest_level.zero?}> "


### PR DESCRIPTION
Pry::RC_FILES went away recently, in this commit:
  https://github.com/pry/pry/commit/d830ebbacc6ebaf60261855ef6011bd6b9d47d8d

The hooks should work both in 0.9.10 and HEAD pry.

Also, gave the user a hint about ~/.guardrc, because it changes the
interactor experience quite a bit with/without one.
