### PR TITLE
Adds comments regarding emacs and Terminal Notifier support

### DIFF
--- a/lib/guard/notifier.rb
+++ b/lib/guard/notifier.rb
@@ -12,6 +12,8 @@ module Guard
   # * GrowlNotify
   # * Libnotify
   # * rb-notifu
+  # * emacs
+  # * Terminal Notifier
   #
   # Please see the documentation of each notifier for more information about the requirements
   # and configuration possibilities.


### PR DESCRIPTION
I noticed that emacs and Terminal Notifier weren't listed in the supported notifiers in `lib/guard/notifier.rb`, so I just added two lines, one for each. Thanks.
