### PR TITLE
Allow overriding Emacs notifier options via Guardfile

### DIFF
--- a/lib/guard/notifiers/emacs.rb
+++ b/lib/guard/notifiers/emacs.rb
@@ -42,6 +42,7 @@ module Guard
       # @param [Hash] options additional notification library options
       # @option options [String] success the color to use for success notifications (default is 'ForestGreen')
       # @option options [String] failed the color to use for failure notifications (default is 'Firebrick')
+      # @option options [String] pending the color to use for pending notifications
       # @option options [String] default the default color to use (default is 'Black')
       # @option options [String] client the client to use for notification (default is 'emacsclient')
       # @option options [String, Integer] priority specify an int or named key (default is 0)
@@ -59,18 +60,13 @@ module Guard
       # @param [Hash] options aditional notification options
       # @option options [String] success the color to use for success notifications (default is 'ForestGreen')
       # @option options [String] failed the color to use for failure notifications (default is 'Firebrick')
+      # @option options [String] pending the color to use for pending notifications
       # @option options [String] default the default color to use (default is 'Black')
       # @return [String] the name of the emacs color
       #
       def emacs_color(type, options = {})
-        case type
-        when 'success'
-          options[:success] || DEFAULTS[:success]
-        when 'failed'
-          options[:failed]  || DEFAULTS[:failed]
-        else
-          options[:default] || DEFAULTS[:default]
-        end
+        default = options[:default] || DEFAULTS[:default]
+        options.fetch(type.to_sym, default)
       end
     end
   end

--- a/spec/guard/notifiers/emacs_spec.rb
+++ b/spec/guard/notifiers/emacs_spec.rb
@@ -35,5 +35,18 @@ describe Guard::Notifier::Emacs do
         subject.notify('success', 'any title', 'any message', 'any image', options)
       end
     end
+
+    context 'when a color option is specified for "pending" notifications' do
+      let(:options) { {:pending => 'Yellow'} }
+
+      it 'should set modeline color to the specified color using emacsclient' do
+        subject.should_receive(:system).with do |command|
+          command.should include("emacsclient")
+          command.should include("(set-face-background 'modeline \\\"Yellow\\\")")
+        end
+
+        subject.notify('pending', 'any title', 'any message', 'any image', options)
+      end
+    end
   end
 end


### PR DESCRIPTION
The first patch allows general overriding of the `DEFAULTS` options in the emacs notifier.

The second patch adds the ability to override options that don't exist in `DEFAULTS`. For example, a custom color can be set for 'pending' notifications (instead of just falling back to `DEFAULTS[:default]`)  by providing a `:pending` option to the `notification` method.

This allows the Guardfile to look something like:

``` ruby
emacs_colors = {
  :success => 'Green',
  :pending => 'Yellow',
  :failed  => 'Red',
  :default => 'White',
}
notification :emacs, emacs_colors
```

Please let me know if if there is anything that you'd like to be done differently.
