### PR TITLE
Add option for tmux message foreground color

### DIFF
--- a/lib/guard/notifiers/tmux.rb
+++ b/lib/guard/notifiers/tmux.rb
@@ -25,6 +25,7 @@ module Guard
         :timeout                => 5,
         :display_message        => false,
         :default_message_format => '%s - %s',
+        :default_message_color  => 'white',
         :line_separator         => ' - ',
         :color_location         => 'status-left-bg'
       }
@@ -74,6 +75,7 @@ module Guard
       #
       def display_message(type, title, message, options = { })
           message_format = options["#{ type }_message_format".to_sym] || options[:default_message_format] || DEFAULTS[:default_message_format]
+          message_color = options[:default_message_color] || DEFAULTS[:default_message_color]
           display_time = options[:timeout] || DEFAULTS[:timeout]
           separator = options[:line_separator] || DEFAULTS[:line_separator]
 
@@ -82,6 +84,7 @@ module Guard
           display_message = message_format % [title, formatted_message]
 
           system("#{ DEFAULTS[:client] } set display-time #{ display_time * 1000 }")
+          system("#{ DEFAULTS[:client] } set message-fg #{ message_color }")
           system("#{ DEFAULTS[:client] } set message-bg #{ color }")
           system("#{ DEFAULTS[:client] } display-message '#{ display_message }'")
       end


### PR DESCRIPTION
Currently it uses whatever tmux's default foreground color is set to. For someone using the tmux solarized theme this is orange. A failure background of bright red with orange text is almost impossible to read.

I've added an option to set the foreground color defaulting it to white.
