### PR TITLE
Introduce grouping of the notifiers.

### DIFF
--- a/lib/guard/notifier.rb
+++ b/lib/guard/notifier.rb
@@ -52,19 +52,21 @@ module Guard
 
     extend self
 
-    # List of available notifiers. It needs to be a nested hash instead of
+    # List of available notifiers, grouped by functionality. It needs to be a nested hash instead of
     # a simpler Hash, because it maintains its order on Ruby 1.8.7 also.
     NOTIFIERS = [
-      [:growl,             ::Guard::Notifier::Growl],
-      [:gntp,              ::Guard::Notifier::GNTP],
-      [:growl_notify,      ::Guard::Notifier::GrowlNotify],
-      [:libnotify,         ::Guard::Notifier::Libnotify],
-      [:notifysend,        ::Guard::Notifier::NotifySend],
-      [:notifu,            ::Guard::Notifier::Notifu],
-      [:emacs,             ::Guard::Notifier::Emacs],
-      [:terminal_notifier, ::Guard::Notifier::TerminalNotifier],
-      [:terminal_title,    ::Guard::Notifier::TerminalTitle],
-      [:tmux,              ::Guard::Notifier::Tmux]
+      [
+        [:gntp,              ::Guard::Notifier::GNTP],
+        [:growl,             ::Guard::Notifier::Growl],
+        [:growl_notify,      ::Guard::Notifier::GrowlNotify],
+        [:terminal_notifier, ::Guard::Notifier::TerminalNotifier],
+        [:libnotify,         ::Guard::Notifier::Libnotify],
+        [:notifysend,        ::Guard::Notifier::NotifySend],
+        [:notifu,            ::Guard::Notifier::Notifu]
+      ],
+      [[:emacs,             ::Guard::Notifier::Emacs]],
+      [[:tmux,              ::Guard::Notifier::Tmux]],
+      [[:terminal_title,    ::Guard::Notifier::TerminalTitle]]
     ]
 
     # Get the available notifications.
@@ -171,16 +173,22 @@ module Guard
     # @return [Module] the notifier module
     #
     def get_notifier_module(name)
-      notifier = NOTIFIERS.detect { |n| n.first == name }
+      notifier = NOTIFIERS.flatten(1).detect { |n| n.first == name }
       notifier ? notifier.last : notifier
     end
 
     # Auto detect the available notification library. This goes through
     # the list of supported notification gems and picks the first that
-    # is available.
+    # is available in each notification group.
     #
     def auto_detect_notification
-      available = NOTIFIERS.map { |n| n.first }.any? { |notifier| add_notification(notifier, { }, true) }
+      available = nil
+
+      NOTIFIERS.each do |group|
+        added = group.map { |n| n.first }.find { |notifier| add_notification(notifier, { }, true) }
+        available = available || added
+      end
+
       ::Guard::UI.info('Guard could not detect any of the supported notification libraries.') unless available
     end
 

--- a/spec/guard/notifier_spec.rb
+++ b/spec/guard/notifier_spec.rb
@@ -31,24 +31,39 @@ describe Guard::Notifier do
         end
 
         it 'tries to add each available notification silently' do
-          Guard::Notifier.should_receive(:add_notification).with(:growl_notify, { }, true).and_return false
           Guard::Notifier.should_receive(:add_notification).with(:gntp, { }, true).and_return false
           Guard::Notifier.should_receive(:add_notification).with(:growl, { }, true).and_return false
+          Guard::Notifier.should_receive(:add_notification).with(:growl_notify, { }, true).and_return false
+          Guard::Notifier.should_receive(:add_notification).with(:terminal_notifier, { }, true).and_return false
           Guard::Notifier.should_receive(:add_notification).with(:libnotify, { }, true).and_return false
           Guard::Notifier.should_receive(:add_notification).with(:notifysend, { }, true).and_return false
           Guard::Notifier.should_receive(:add_notification).with(:notifu, { }, true).and_return false
           Guard::Notifier.should_receive(:add_notification).with(:emacs, { }, true).and_return false
-          Guard::Notifier.should_receive(:add_notification).with(:terminal_notifier, { }, true).and_return false
           Guard::Notifier.should_receive(:add_notification).with(:terminal_title, { }, true).and_return false
           Guard::Notifier.should_receive(:add_notification).with(:tmux, { }, true).and_return false
           Guard::Notifier.turn_on
         end
 
+        it 'adds only the first notification per group' do
+          Guard::Notifier.should_receive(:add_notification).with(:gntp, { }, true).and_return false
+          Guard::Notifier.should_receive(:add_notification).with(:growl, { }, true).and_return false
+          Guard::Notifier.should_receive(:add_notification).with(:growl_notify, { }, true).and_return true
+          Guard::Notifier.should_not_receive(:add_notification).with(:terminal_notifier, { }, true)
+          Guard::Notifier.should_not_receive(:add_notification).with(:libnotify, { }, true)
+          Guard::Notifier.should_not_receive(:add_notification).with(:notifysend, { }, true)
+          Guard::Notifier.should_not_receive(:add_notification).with(:notifu, { }, true)
+          Guard::Notifier.should_receive(:add_notification).with(:emacs, { }, true)
+          Guard::Notifier.should_receive(:add_notification).with(:terminal_title, { }, true)
+          Guard::Notifier.should_receive(:add_notification).with(:tmux, { }, true)
+          Guard::Notifier.turn_on
+        end
+
+
         it 'does enable the notifications when a library is available' do
           Guard::Notifier.should_receive(:add_notification) do
             Guard::Notifier.notifications = [{ :name => :gntp, :options => { } }]
             true
-          end
+          end.any_number_of_times
           Guard::Notifier.turn_on
           Guard::Notifier.should be_enabled
         end


### PR DESCRIPTION
This groups the notifiers, so that the auto
detection features only enables one notifier per group.

This speeds up the auto detection a little bit and doesn't
activate for example two different Growl libraries.
