### PR TITLE
Bugfix: Do not modify original message in terminal_title notifier

### DIFF
--- a/lib/guard/notifiers/terminal_title.rb
+++ b/lib/guard/notifiers/terminal_title.rb
@@ -22,9 +22,8 @@ module Guard
       # @param [Hash] options additional notification library options
       #
       def notify(type, title, message, image, options = { })
-        message.sub!(/^\n/, '')
-        message.sub!(/\n.*/m, '')
-        set_terminal_title("[#{title}] #{message}")
+        first_line = message.sub(/^\n/, '').sub(/\n.*/m, '')
+        set_terminal_title("[#{title}] #{first_line}")
       end
 
       def set_terminal_title(text)

--- a/spec/guard/notifiers/terminal_title_spec.rb
+++ b/spec/guard/notifiers/terminal_title_spec.rb
@@ -28,9 +28,14 @@ describe Guard::Notifier::TerminalTitle do
   end
 
   describe '.notify' do
+    long_message = "first line\nsecond line\nthird"
     it 'set title + first line of message to terminal title' do
       subject.should_receive(:set_terminal_title).with("[any title] first line")
-      subject.notify('success', 'any title', "first line\nsecond line\nthird", 'any image', { })
+      subject.notify('success', 'any title', long_message, 'any image', { })
+    end
+
+    it 'does not change original message' do
+      long_message.should eq("first line\nsecond line\nthird")
     end
   end
 


### PR DESCRIPTION
Fixed bug, that cut off second and following lines from output message
(introduced in commit 5da3704ca1).
