### PR TITLE
Replace /dev/null with NUL on Windows; Handle shell echo quotes

### DIFF
--- a/lib/guard.rb
+++ b/lib/guard.rb
@@ -1,3 +1,4 @@
+require 'rbconfig'
 require 'thread'
 require 'listen'
 
@@ -20,6 +21,9 @@ module Guard
 
   # The location of user defined templates
   HOME_TEMPLATES = File.expand_path('~/.guard/templates')
+
+  WINDOWS = RbConfig::CONFIG["host_os"] =~ %r!(msdos|mswin|djgpp|mingw)!
+  DEV_NULL = WINDOWS ? "NUL" : "/dev/null"
 
   class << self
     attr_accessor :options, :interactor, :runner, :listener, :lock

--- a/lib/guard/interactor.rb
+++ b/lib/guard/interactor.rb
@@ -208,13 +208,13 @@ module Guard
     # when stopping.
     #
     def store_terminal_settings
-      @stty_save = `stty -g 2>/dev/null`.chomp
+      @stty_save = `stty -g 2>#{DEV_NULL}`.chomp
     end
 
     # Restore terminal settings
     #
     def restore_terminal_settings
-      system("stty #{ @stty_save } 2>/dev/null") if @stty_save
+      system("stty #{ @stty_save } 2>#{DEV_NULL}") if @stty_save
     end
 
     # Converts and validates a plain text scope

--- a/lib/guard/notifiers/emacs.rb
+++ b/lib/guard/notifiers/emacs.rb
@@ -24,9 +24,9 @@ module Guard
       # @return [Boolean] the availability status
       #
       def available?(silent = false)
-        result = `#{ DEFAULTS[:client] } --eval '1' 2> /dev/null || echo 'N/A'`
+        result = `#{ DEFAULTS[:client] } --eval '1' 2> #{DEV_NULL} || echo 'N/A'`
 
-        if result.chomp! == 'N/A'
+        if ["N/A", "'N/A'"].include?(result.chomp!)
           false
         else
           true


### PR DESCRIPTION
- Replace use of '/dev/null' with DEV_NULL, a constant that is evaluated at load time. This snippet for identifying Windows and calculating the null device name is copied from bundler (see https://github.com/carlhuda/bundler/blob/054329690071974180393a4f14ec3fa2984bc446/lib/bundler.rb#L65-67)
- Handle the case where quotes in the argument of an echo command may or may not be included in the result depending on OS. On Windows, the shell command "ECHO 'a'" returns "'a'" (with quotes). On Linux, the shell command "ECHO 'a'" returns "a" (without quotes).
