### PR TITLE
Also change modeline's fgcolor when changing bgcolor in emacs notifier

### DIFF
--- a/lib/guard/notifiers/emacs.rb
+++ b/lib/guard/notifiers/emacs.rb
@@ -12,10 +12,11 @@ module Guard
       extend self
 
       DEFAULTS = {
-        :client  => 'emacsclient',
-        :success => 'ForestGreen',
-        :failed  => 'Firebrick',
-        :default => 'Black',
+        :client    => 'emacsclient',
+        :success   => 'ForestGreen',
+        :failed    => 'Firebrick',
+        :default   => 'Black',
+        :fontcolor => 'White',
       }
 
       # Test if Emacs with running server is available.
@@ -48,9 +49,10 @@ module Guard
       # @option options [String, Integer] priority specify an int or named key (default is 0)
       #
       def notify(type, title, message, image, options = { })
-        options = DEFAULTS.merge options
-        color   = emacs_color type, options
-        system(%(#{ options[:client] } --eval "(set-face-background 'modeline \\"#{ color }\\")"))
+        options   = DEFAULTS.merge options
+        color     = emacs_color type, options
+        fontcolor = emacs_color :fontcolor, options
+        system(%(#{ options[:client] } --eval "(set-face-attribute 'mode-line nil :background \\"#{ color }\\" :foreground \\"#{ fontcolor }\\")"))
       end
 
       # Get the Emacs color for the notification type.

--- a/spec/guard/notifiers/emacs_spec.rb
+++ b/spec/guard/notifiers/emacs_spec.rb
@@ -7,7 +7,7 @@ describe Guard::Notifier::Emacs do
       it 'should set modeline color to the default color using emacsclient' do
         subject.should_receive(:system).with do |command|
           command.should include("emacsclient")
-          command.should include("(set-face-background 'modeline \\\"ForestGreen\\\")")
+          command.should include("(set-face-attribute 'mode-line nil :background \\\"ForestGreen\\\" :foreground \\\"White\\\")")
         end
 
         subject.notify('success', 'any title', 'any message', 'any image', { })
@@ -20,7 +20,7 @@ describe Guard::Notifier::Emacs do
       it 'should set modeline color to the specified color using emacsclient' do
         subject.should_receive(:system).with do |command|
           command.should include("emacsclient")
-          command.should include("(set-face-background 'modeline \\\"Orange\\\")")
+          command.should include("(set-face-attribute 'mode-line nil :background \\\"Orange\\\" :foreground \\\"White\\\")")
         end
 
         subject.notify('success', 'any title', 'any message', 'any image', options)
@@ -33,7 +33,7 @@ describe Guard::Notifier::Emacs do
       it 'should set modeline color to the specified color using emacsclient' do
         subject.should_receive(:system).with do |command|
           command.should include("emacsclient")
-          command.should include("(set-face-background 'modeline \\\"Yellow\\\")")
+          command.should include("(set-face-attribute 'mode-line nil :background \\\"Yellow\\\" :foreground \\\"White\\\")")
         end
 
         subject.notify('pending', 'any title', 'any message', 'any image', options)


### PR DESCRIPTION
Set fgcolor to white. When guard sets status to default - bgcolor black - and you are using a theme with black fonts in modeline the text becomes unvisible. 
