### PR TITLE
`bundle exec guard init` is adding duplicate definitions to the Guardfile

### DIFF
--- a/lib/guard/guardfile.rb
+++ b/lib/guard/guardfile.rb
@@ -30,6 +30,24 @@ module Guard
         end
       end
 
+      # Opens an existing guardfile and searches for redundant definitions
+      # if extraneous defintions are found, it warns the user
+      #
+      # @see Guard::CLI.init
+      #
+      # @param [String] class name of gem definition that you would like to search for in the Guardfile
+      # @param [String] contents of existing guardfile
+      #
+      def duplicate_definitions?(guard_class, guard_file)
+        matches = guard_file.to_s.scan(/guard\s[\'|\"]#{guard_class}[\'|\"]\sdo/)
+        if matches.count > 1
+          ::Guard::UI.info "There are #{matches.count.to_s} definitions in your Guardfile for '#{guard_class}', you may want to clean up your Guardfile as this could cause issues."
+          return true
+        else
+          return false
+        end
+      end
+
       # Adds the Guardfile template of a Guard implementation
       # to an existing Guardfile.
       #
@@ -42,6 +60,9 @@ module Guard
 
         if guard_class
           guard_class.init(guard_name)
+          guardfile_name = 'Guardfile'
+          guard_file = File.read(guardfile_name) if File.exists?(guardfile_name)
+          duplicate_definitions?(guard_name, guard_file)
         elsif File.exist?(File.join(HOME_TEMPLATES, guard_name))
           content  = File.read('Guardfile')
           template = File.read(File.join(HOME_TEMPLATES, guard_name))

--- a/spec/guard/guardfile_spec.rb
+++ b/spec/guard/guardfile_spec.rb
@@ -46,6 +46,24 @@ describe Guard::Guardfile do
     end
   end
 
+  describe ".duplicate_defintions?" do
+    context "that finds an existing Guardfile"  do
+      context "that has duplicate definitions" do
+        it "should return true" do
+          io = StringIO.new("guard 'rspec' do\nend\nguard 'rspec' do\nend\n")
+          Guard::Guardfile.duplicate_definitions?('rspec', io.string).should == true
+        end
+      end
+
+      context "that doesn't have duplicate definitions" do
+        it "should return false" do
+          io = StringIO.new("guard 'rspec' do\nend\n")
+          Guard::Guardfile.duplicate_definitions?('rspec', io.string).should == false
+        end
+      end
+    end
+  end
+
   describe ".initialize_template" do
     context 'with an installed Guard implementation' do
       let(:foo_guard) { double('Guard::Foo').as_null_object }


### PR DESCRIPTION
Hello,

In using guard, I found that the specs were running twice. I Google'd around and found several cases where other users were complaining of similar issues. I finally came to understand that it was because there were duplicate definitions in the Guardfile. In my case, the duplications were the result of me accidentally running `guard init` 1+n times and not being keen to the fact that I had done this.

I do not know if this functionality is by design, but I implemented the basic spec tests and code to detect if there were multiple definitions and alert the user to their existence.

Example:

[jfolkins@jfolkins-mbp:~/Programming/Ruby/guard]$ bundle exec guard init
16:40:15 - INFO - ronn guard added to Guardfile, feel free to edit it
16:40:15 - INFO - There are 23 definitions in your Guardfile for 'ronn', you may want to clean up your Guardfile as this could cause issues.
16:40:15 - INFO - rspec guard added to Guardfile, feel free to edit it
16:40:15 - INFO - There are 20 definitions in your Guardfile for 'rspec', you may want to clean up your Guardfile as this could cause issues.

How to duplicate my findings on OSX 10.7.5:

`cd ~`
`git clone git@github.com:guard/guard.git`
`cd guard`
`vi Gemfile`
# Add the following line and :wq

`gem 'guard', :path => '~/guard/'`

`rvm --create ruby-1.9.2-p290@guard_test_jfolkins_pre`
`bundle install`
`bundle exec guard init`
`bundle exec guard init`
`cat Guardfile`

From here you will hopefully see multiple definitions.

How to test my proposal:

`cd ~`
`git clone git@github.com:jfolkins/guard.git`
`cd guard`
`vi Gemfile`
# Add the following line and :wq

gem 'guard', :path => '~/guard/'

`rvm --create ruby-1.9.2-p290@guard_test_jfolkins_post`
`bundle install`
`bundle exec guard init`
`bundle exec guard init`
# warning will be here

Value Proposition:

I believe the solution I have implemented is a reasonable way to clue in the user to potential issues in their Guard file. In my case, I thought it was Guard being buggy and this barrier almost had me drop the use of it in my project. Instead, I decided to be proactive and solve this issue for others.

Thanks for your time and for the software!
jared
