### PR TITLE
allow guards to specify their templates

### DIFF
--- a/lib/guard/guard.rb
+++ b/lib/guard/guard.rb
@@ -58,7 +58,11 @@ module Guard
       @watchers, @options = watchers, options
     end
 
-    
+    # Specify the source for the Guardfile template.
+    # Each Guard plugin can redefine this method to add its own logic.
+    # 
+    # @param [String] The plugin name
+    # 
     def self.template(name)
       File.read("#{ ::Guard.locate_guard(name) }/lib/guard/#{ name }/templates/Guardfile")
     end


### PR DESCRIPTION
I was playing with the idea of embedding the guard in the gem it supports and while it works "guard init" does not because guard expects the guard to live in a separate gem and hardcode its search path.

Why hardcode something that does not need to be ?
Once the guard class has been found no magic should happen to find any related location or files...

What do you think ?
