### PR TITLE
List plugins embedded in non dedicated gem

### DIFF
--- a/lib/guard.rb
+++ b/lib/guard.rb
@@ -404,7 +404,14 @@ module Guard
     #
     def guard_gem_names
       if Gem::Version.create(Gem::VERSION) >= Gem::Version.create('1.8.0')
-        Gem::Specification.find_all.select { |x| x.name =~ /^guard-/ }
+        Gem::Specification.find_all.select do |x|
+          if x.name =~ /^guard-/
+            true
+          elsif x.name != "guard"
+            guard_plugin_path = File.join(x.full_gem_path, "lib/guard/#{x.name}.rb")
+            File.exists?( guard_plugin_path )
+          end
+        end
       else
         Gem.source_index.find_name(/^guard-/)
       end.map { |x| x.name.sub(/^guard-/, '') }

--- a/spec/guard_spec.rb
+++ b/spec/guard_spec.rb
@@ -780,6 +780,20 @@ describe Guard do
       gems = Guard.guard_gem_names
       gems.should include("rspec")
     end
+    
+    it "returns the list of embedded guard gems" do
+      gem1 = stub(:gem, :name => "gem1", :full_gem_path => '/gem1' )
+      gem2 = stub(:gem, :name => "gem2", :full_gem_path => '/gem2' )
+      gem3 = stub(:gem, :name => "guard", :full_gem_path => '/guard' )
+      
+      File.should_receive(:exists?).with('/gem1/lib/guard/gem1.rb').and_return(false)
+      File.should_receive(:exists?).with('/gem2/lib/guard/gem2.rb').and_return(true)
+      
+      Gem::Specification.should_receive(:find_all).and_return([gem1, gem2, gem3])
+      
+      Guard.guard_gem_names.should == ['gem2']
+    end
+
   end
 
   describe ".debug_command_execution" do


### PR DESCRIPTION
It looks like it was easier than I thought !

this change includes in the "guard list" output guard plugins which are not in a "guard-xxx" gem by looking inside the gem folder if a "lib/guard/<gem_name>.rb" file is available.

I only updated the code for rubygems 1.8.0+ since I am not sure about the api provided below.
