### PR TITLE
Readme: Underlines sys notifications header

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ group :development do
 end
 ```
 
-### System notifications
+## System notifications
 
 You can configure Guard to make use of the following system notification libraries:
 


### PR DESCRIPTION
To keep consistent with the rest of the section headers
