### PR TITLE
The shortcut for --plugins is `-P` (upper, not lowercase)

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ Scope Guard to certain plugins on start:
 
 ```bash
 $ guard --plugins plugin_name another_plugin_name
-$ guard -p plugin_name another_plugin_name # shortcut
+$ guard -P plugin_name another_plugin_name # shortcut
 ```
 
 #### `-d`/`--debug` option


### PR DESCRIPTION
Fix a typo in the `--plugins` example in the README.
