### PR TITLE
Restore tmux options immediately after each notification

### DIFF
--- a/lib/guard/notifiers/tmux.rb
+++ b/lib/guard/notifiers/tmux.rb
@@ -103,11 +103,7 @@ module Guard
         system("#{ DEFAULTS[:client] } set display-time #{ display_time * 1000 }")
         system("#{ DEFAULTS[:client] } set message-fg #{ message_color }")
         system("#{ DEFAULTS[:client] } set message-bg #{ color }")
-        Thread.new do
-          system("#{ DEFAULTS[:client] } display-message '#{ display_message }'")
-          sleep display_time
-          restore_options
-        end
+        display_and_restore(display_message, display_time)
       end
 
       # Get the Tmux color for the notification type.
@@ -162,6 +158,16 @@ module Guard
       end
 
       private
+
+      # Displays the message, waits for it to disappear
+      #
+      def display_and_restore(message, delay)
+        Thread.new do
+          system("#{ DEFAULTS[:client] } display-message '#{ message }'")
+          sleep delay
+          restore_options
+        end
+      end
 
       # Restore Tmux options to the ones saved before displaying messages
       #


### PR DESCRIPTION
I use tmux messages for all kinds of things. When using the tmux notifier in Guard it messes up the settings for these messages. This change restores the options immediately after the notification disappears so that other messages display with the defaults.
