### PR TITLE
call File.expand_path on history_file

### DIFF
--- a/lib/guard/interactor.rb
+++ b/lib/guard/interactor.rb
@@ -87,7 +87,7 @@ module Guard
 
       Pry.config.should_load_rc       = false
       Pry.config.should_load_local_rc = false
-      Pry.config.history.file         = self.class.options[:history_file] || HISTORY_FILE
+      Pry.config.history.file         = File.expand_path(self.class.options[:history_file] || HISTORY_FILE)
 
       add_hooks
 


### PR DESCRIPTION
`File.expand_path` isn't called on the `history_file` variable, which causes a `~` directory to be created in the project in which guard is called, instead of using the home directory.
