### PR TITLE
avoid spurious 'nil' output from emacs notifier

### DIFF
--- a/lib/guard/notifiers/emacs.rb
+++ b/lib/guard/notifiers/emacs.rb
@@ -52,7 +52,12 @@ module Guard
         options   = DEFAULTS.merge options
         color     = emacs_color type, options
         fontcolor = emacs_color :fontcolor, options
-        system(%(#{ options[:client] } --eval "(set-face-attribute 'mode-line nil :background \\"#{ color }\\" :foreground \\"#{ fontcolor }\\")"))
+        elisp = <<-EOF.gsub(/\s+/, ' ').strip
+          (set-face-attribute 'mode-line nil
+               :background "#{color}"
+               :foreground "#{fontcolor}")
+        EOF
+        run_cmd [ options[:client], '--eval', elisp ]
       end
 
       # Get the Emacs color for the notification type.
@@ -69,6 +74,12 @@ module Guard
       def emacs_color(type, options = {})
         default = options[:default] || DEFAULTS[:default]
         options.fetch(type.to_sym, default)
+      end
+
+      private
+
+      def run_cmd(args)
+        IO.popen(args).readlines
       end
     end
   end

--- a/spec/guard/notifiers/emacs_spec.rb
+++ b/spec/guard/notifiers/emacs_spec.rb
@@ -5,9 +5,9 @@ describe Guard::Notifier::Emacs do
   describe '.notify' do
     context 'when no color options are specified' do
       it 'should set modeline color to the default color using emacsclient' do
-        subject.should_receive(:system).with do |command|
+        subject.should_receive(:run_cmd).with do |command|
           command.should include("emacsclient")
-          command.should include("(set-face-attribute 'mode-line nil :background \\\"ForestGreen\\\" :foreground \\\"White\\\")")
+          command.should include(%{(set-face-attribute 'mode-line nil :background "ForestGreen" :foreground "White")})
         end
 
         subject.notify('success', 'any title', 'any message', 'any image', { })
@@ -18,9 +18,9 @@ describe Guard::Notifier::Emacs do
       let(:options) { {:success => 'Orange'} }
 
       it 'should set modeline color to the specified color using emacsclient' do
-        subject.should_receive(:system).with do |command|
+        subject.should_receive(:run_cmd).with do |command|
           command.should include("emacsclient")
-          command.should include("(set-face-attribute 'mode-line nil :background \\\"Orange\\\" :foreground \\\"White\\\")")
+          command.should include(%{(set-face-attribute 'mode-line nil :background "Orange" :foreground "White")})
         end
 
         subject.notify('success', 'any title', 'any message', 'any image', options)
@@ -31,9 +31,9 @@ describe Guard::Notifier::Emacs do
       let(:options) { {:pending => 'Yellow'} }
 
       it 'should set modeline color to the specified color using emacsclient' do
-        subject.should_receive(:system).with do |command|
+        subject.should_receive(:run_cmd).with do |command|
           command.should include("emacsclient")
-          command.should include("(set-face-attribute 'mode-line nil :background \\\"Yellow\\\" :foreground \\\"White\\\")")
+          command.should include(%{(set-face-attribute 'mode-line nil :background "Yellow" :foreground "White")})
         end
 
         subject.notify('pending', 'any title', 'any message', 'any image', options)


### PR DESCRIPTION
The emacs notifier was causing guard to output a line saying 'nil'
every time emacsclient was invoked.  Now the stdout from emacsclient
is discarded.
