### PR TITLE
If there is a .guardrc file on the folder from which Guard is executed, then load it too.

### DIFF
--- a/lib/guard/interactor.rb
+++ b/lib/guard/interactor.rb
@@ -103,6 +103,7 @@ module Guard
     # Add Pry hooks:
     #
     # * Load `~/.guardrc` within each new Pry session.
+    # * Load project's `.guardrc` within each new Pry session.
     # * Restore prompt after each evaluation.
     #
     def add_hooks
@@ -110,6 +111,11 @@ module Guard
         (self.class.options[:guard_rc] || GUARD_RC).tap do |p|
           load p if File.exist?(File.expand_path(p))
         end
+      end
+
+      Pry.config.hooks.add_hook :when_started, :load_project_guard_rc do
+        project_guard_rc = Dir.pwd + '/.guardrc'
+        load project_guard_rc if File.exist?(project_guard_rc)
       end
 
       if stty_exists?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,6 +43,7 @@ RSpec.configure do |config|
 
   config.after(:each) do
     Pry.config.hooks.delete_hook(:when_started, :load_guard_rc)
+    Pry.config.hooks.delete_hook(:when_started, :load_project_guard_rc)
 
     if ::Guard.options
       ::Guard.options[:debug] = false


### PR DESCRIPTION
If there is a .guardrc file on the folder from which Guard is executed, then load it too.

Related to:  #415

I am not sure if I have to add any spec for this. I tested it by building this gem from my branch and using it on one of my projects; and it worked.
