### PR TITLE
Removed outdated section about filesystem handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,37 +66,6 @@ $ guard init
 If you are on Mac OS X and have problems with either Guard not reacting to file changes or Pry behaving strange, then
 you should [add proper Readline support to Ruby on Mac OS X](https://github.com/guard/guard/wiki/Add-proper-Readline-support-to-Ruby-on-Mac-OS-X).
 
-## Efficient Filesystem Handling
-
-Various operating systems are willing to notify you of changes to files, but the API to register/receive updates varies
-(see [rb-fsevent](https://github.com/thibaudgg/rb-fsevent) for OS X, [rb-inotify](https://github.com/nex3/rb-inotify)
-for Linux, and [rb-fchange](https://github.com/stereobooster/rb-fchange) for Windows). If you do not supply one of the
-supported gems for these methods, Guard will fall back to polling, and give you a warning about it doing so.
-
-A challenge arises when trying to make these dependencies work with [Bundler](http://gembundler.com/). If you simply put
-one of these dependencies into you `Gemfile`, even if it is conditional on a platform match, the platform-specific gem
-will end up in the `Gemfile.lock`, and developers will thrash the file back and forth.
-
-There is a good solution. All three gems will successfully, quietly install on all three operating systems, and
-`guard/listen` will only pull in the one you need. This is a more proper `Gemfile`:
-
-```Ruby
-group :development do
-  gem 'rb-inotify', :require => false
-  gem 'rb-fsevent', :require => false
-  gem 'rb-fchange', :require => false
-end
-```
-
-If you're using Windows and at least Ruby 1.9.2, then [Windows Directory Monitor](https://github.com/Maher4Ever/wdm) is
-more efficient than using `rb-fchange`.
-
-```Ruby
-group :development do
-  gem 'wdm', :platforms => [:mswin, :mingw], :require => false
-end
-```
-
 ## Windows Colors
 
 If you want colors in your terminal, you'll have to add the [win32console](https://rubygems.org/gems/win32console) gem


### PR DESCRIPTION
Filesystem adapters are now handled by the Listen gem.

Therefore I propose to delete this entire section, since this is all handled transparently. I have created a Wiki page and moved the content there. https://github.com/guard/guard/wiki/Efficient-Filesystem-Handling
