### PR TITLE
Fix for notifications not working when using Zeus

### DIFF
--- a/lib/guard/notifier.rb
+++ b/lib/guard/notifier.rb
@@ -170,6 +170,8 @@ module Guard
     # @option options [String] title the notification title
     #
     def notify(message, options = { })
+      turn_on if ENV['GUARD_NOTIFY'].nil? # Fixes notifications not showing when using Zeus.
+
       if enabled?
         type  = notification_type(options[:image] || :success)
         image = image_path(options.delete(:image) || :success)


### PR DESCRIPTION
When Zeus is been used, notifications are not been processed. Guard settings are not been initialized for notifications due to the process separation and this is disabling notifications.
