### PR TITLE
Refactor notifiers

### DIFF
--- a/lib/guard/dsl.rb
+++ b/lib/guard/dsl.rb
@@ -71,7 +71,7 @@ module Guard
     # @see Guard::Notifier for available notifier and its options.
     #
     def notification(notifier, options = {})
-      ::Guard::Notifier.add_notification(notifier.to_sym, options, false)
+      ::Guard::Notifier.add_notifier(notifier.to_sym, options.merge(:silent => false))
     end
 
     # Sets the interactor options or disable the interactor.

--- a/lib/guard/guardfile/evaluator.rb
+++ b/lib/guard/guardfile/evaluator.rb
@@ -180,7 +180,7 @@ module Guard
         ::Guard.runner.run(:stop)
         ::Guard.reset_groups
         ::Guard.reset_plugins
-        ::Guard::Notifier.clear_notifications
+        ::Guard::Notifier.clear_notifiers
 
         options.delete(:guardfile_contents)
       end

--- a/lib/guard/notifiers/base.rb
+++ b/lib/guard/notifiers/base.rb
@@ -1,0 +1,220 @@
+require 'rbconfig'
+require 'guard/ui'
+
+module Guard
+  module Notifier
+
+    # Base class for all notifiers.
+    #
+    class Base
+
+      HOSTS = {
+        :darwin  => 'Mac OS X',
+        :linux   => 'Linux',
+        :freebsd => 'FreeBSD',
+        :openbsd => 'OpenBSD',
+        :sunos   => 'SunOS',
+        :solaris => 'Solaris',
+        :mswin   => 'Windows',
+        :mingw   => 'Windows',
+        :cygwin  => 'Windows'
+      }
+
+      attr_reader :options
+
+      def initialize(opts = {})
+        @options = opts
+      end
+
+      # This method should be overriden by subclasses and return an array of
+      # OSes the notifier supports. By default, it returns :all which mean
+      # there's no check against the current OS.
+      #
+      # @see HOSTS for the list of possible OSes
+      #
+      def self.supported_hosts
+        :all
+      end
+
+      # Test if the notifier can be used.
+      #
+      # @param [Hash] opts notifier options
+      # @option opts [Boolean] silent true if no error messages should be shown
+      # @return [Boolean] the availability status
+      #
+      def self.available?(opts = {})
+        options = { :silent => false }.merge(opts)
+
+        unless _supported_host?
+          hosts = supported_hosts.map { |host| HOSTS[host.to_sym] }.join(', ')
+          ::Guard::UI.error "The :#{name} notifier runs only on #{hosts}." unless options[:silent]
+          return false
+        end
+
+        true
+      end
+
+      # This method must be implemented.
+      #
+      def notify(message, opts = {})
+        raise NotImplementedError
+      end
+
+      # Returns the title of the notifier.
+      #
+      # @example Un-modulize the class name
+      #   Guard::Notifier::FileNotifier.title
+      #   #=> 'FileNotifier'
+      #
+      # @return [String] the title of the notifier
+      #
+      def self.title
+        self.to_s.sub(/.+::(\w+)$/, '\1')
+      end
+
+      # Returns the name of the notifier.
+      #
+      # @example Un-modulize, underscorize and downcase the class name
+      #   Guard::Notifier::FileNotifier.name
+      #   #=> 'file_notifier'
+      #
+      # @return [String] the name of the notifier
+      #
+      def self.name
+        title.gsub(/([a-z])([A-Z])/, '\1_\2').downcase
+      end
+
+      # Returns the name of the notifier's gem. By default it returns the
+      # notifier name. This method can be overriden by subclasses.
+      #
+      # @example Un-modulize, underscorize and downcase the class name
+      #   Guard::Notifier::FileNotifier.gem_name
+      #   #=> 'file_notifier'
+      #
+      # @return [String] the name of the notifier's gem
+      #
+      def self.gem_name
+        name
+      end
+
+      # This method tries to require the gem whose name is returned by
+      # `.gem_name`. If a LoadError or NameError occurs, it displays an error
+      # message (unless opts[:silent] is true) and returns false.
+      #
+      # @param [Hash] opts some options
+      # @option opts [Boolean] silent true if no error messages should be shown
+      #
+      # @return [Boolean] whether or not the gem is loaded
+      #
+      def self.require_gem_safely(opts = {})
+        require gem_name
+        true
+      rescue LoadError, NameError
+        unless opts[:silent]
+          ::Guard::UI.error "Please add \"gem '#{gem_name}'\" to your Gemfile and run Guard with \"bundle exec\"."
+        end
+        false
+      end
+
+      # Returns the title of the notifier.
+      #
+      # @example Un-modulize the class name
+      #   Guard::Notifier::FileNotifier.new.title
+      #   #=> 'FileNotifier'
+      #
+      # @return [String] the title of the notifier
+      #
+      def title
+        self.class.title
+      end
+
+      # Returns the name of the notifier.
+      #
+      # @example Un-modulize, underscorize and downcase the class name
+      #   Guard::Notifier::FileNotifier.new.name
+      #   #=> 'file_notifier'
+      #
+      # @return [String] the name of the notifier
+      #
+      def name
+        self.class.name
+      end
+
+      # Paths where all Guard images are located
+      #
+      # @return [Pathname] the path to the images directory
+      #
+      def images_path
+        @images_path ||= Pathname.new(File.dirname(__FILE__)).join('../../../images')
+      end
+
+      # @private
+      #
+      # Checks if the current OS is supported by the notifier.
+      #
+      # @see .supported_hosts
+      #
+      def self._supported_host?
+        supported_hosts == :all ||
+        RbConfig::CONFIG['host_os'] =~ /#{supported_hosts.join('|')}/
+      end
+
+      # Set or modify the `:title`, `:type` and `:image` options for a
+      # notification. Should be used in `#notify`.
+      #
+      # @param [Hash] opts additional notification library options
+      # @option opts [String] type the notification type. Either 'success',
+      #   'pending', 'failed' or 'notify'
+      # @option opts [String] title the notification title
+      # @option opts [String] image the path to the notification image
+      #
+      def normalize_standard_options!(opts)
+        opts[:title] ||= 'Guard'
+        opts[:type]  ||= _notification_type(opts.fetch(:image, :success))
+        opts[:image]   = _image_path(opts.delete(:image) { :success })
+      end
+
+      private
+
+      # Get the image path for an image symbol for the following
+      # known image types:
+      #
+      # - failed
+      # - pending
+      # - success
+      #
+      # If the image is not a known symbol, it will be returned unmodified.
+      #
+      # @param [Symbol, String] image the image symbol or path to an image
+      #
+      # @return [String] the image path
+      #
+      def _image_path(image)
+        case image.to_sym
+        when :failed, :pending, :success
+          images_path.join("#{image.to_s}.png").to_s
+        else
+          image
+        end
+      end
+
+      # Get the notification type depending on the
+      # image that has been selected for the notification.
+      #
+      # @param [Symbol, String] image the image symbol or path to an image
+      #
+      # @return [String] the notification type
+      #
+      def _notification_type(image)
+        case image.to_sym
+        when :failed, :pending, :success
+          image.to_sym
+        else
+          :notify
+        end
+      end
+
+    end
+
+  end
+end

--- a/lib/guard/notifiers/emacs.rb
+++ b/lib/guard/notifiers/emacs.rb
@@ -1,4 +1,4 @@
-require 'rbconfig'
+require 'guard/notifiers/base'
 
 module Guard
   module Notifier
@@ -8,8 +8,7 @@ module Guard
     # @example Add the `:emacs` notifier to your `Guardfile`
     #   notification :emacs
     #
-    module Emacs
-      extend self
+    class Emacs < Base
 
       DEFAULTS = {
         :client    => 'emacsclient',
@@ -19,46 +18,47 @@ module Guard
         :fontcolor => 'White',
       }
 
-      # Test if Emacs with running server is available.
-      #
-      # @param [Boolean] silent true if no error messages should be shown
-      # @param [Hash] options notifier options
-      # @return [Boolean] the availability status
-      #
-      def available?(silent = false, options = {})
-        result = `#{ options.fetch(:client, DEFAULTS[:client]) } --eval '1' 2> #{DEV_NULL} || echo 'N/A'`
+      def self.available?(opts = {})
+        super
+        result = `#{ opts.fetch(:client, DEFAULTS[:client]) } --eval '1' 2> #{DEV_NULL} || echo 'N/A'`
 
-        if %w(N/A 'N/A').include?(result.chomp!)
-          false
-        else
-          true
-        end
+        !%w(N/A 'N/A').include?(result.chomp!)
       end
 
-      # Show a system notification.
+      # Shows a system notification.
       #
-      # @param [String] type the notification type. Either 'success', 'pending', 'failed' or 'notify'
+      # @param [String] type the notification type. Either 'success',
+      #   'pending', 'failed' or 'notify'
       # @param [String] title the notification title
       # @param [String] message the notification message body
       # @param [String] image the path to the notification image
-      # @param [Hash] options additional notification library options
-      # @option options [String] success the color to use for success notifications (default is 'ForestGreen')
-      # @option options [String] failed the color to use for failure notifications (default is 'Firebrick')
-      # @option options [String] pending the color to use for pending notifications
-      # @option options [String] default the default color to use (default is 'Black')
-      # @option options [String] client the client to use for notification (default is 'emacsclient')
-      # @option options [String, Integer] priority specify an int or named key (default is 0)
+      # @param [Hash] opts additional notification library options
+      # @option opts [String] success the color to use for success
+      #   notifications (default is 'ForestGreen')
+      # @option opts [String] failed the color to use for failure
+      #   notifications (default is 'Firebrick')
+      # @option opts [String] pending the color to use for pending
+      #   notifications
+      # @option opts [String] default the default color to use (default is
+      #   'Black')
+      # @option opts [String] client the client to use for notification
+      #   (default is 'emacsclient')
+      # @option opts [String, Integer] priority specify an int or named key
+      #   (default is 0)
       #
-      def notify(type, title, message, image, options = {})
-        options   = DEFAULTS.merge options
-        color     = emacs_color type, options
-        fontcolor = emacs_color :fontcolor, options
+      def notify(message, opts = {})
+        normalize_standard_options!(opts)
+
+        opts      = DEFAULTS.merge(opts)
+        color     = emacs_color(opts[:type], opts)
+        fontcolor = emacs_color(:fontcolor, opts)
         elisp = <<-EOF.gsub(/\s+/, ' ').strip
           (set-face-attribute 'mode-line nil
                :background "#{color}"
                :foreground "#{fontcolor}")
         EOF
-        _run_cmd(options[:client], '--eval', elisp)
+
+        _run_cmd(opts[:client], '--eval', elisp)
       end
 
       # Get the Emacs color for the notification type.
@@ -82,6 +82,8 @@ module Guard
       def _run_cmd(*args)
         IO.popen(args).readlines
       end
+
     end
+
   end
 end

--- a/lib/guard/notifiers/file_notifier.rb
+++ b/lib/guard/notifiers/file_notifier.rb
@@ -1,45 +1,47 @@
+require 'guard/notifiers/base'
+
 module Guard
   module Notifier
 
-    # Writes guard notification results to a file
+    # Writes Guard notification results to a file.
     #
     # @example Add the `:file` notifier to your `Guardfile`
     #   notification :file, path: 'tmp/guard_result'
     #
-    module FileNotifier
-      extend self
+    class FileNotifier < Base
 
-      # Default options for FileNotifier
       DEFAULTS = {
         :format => "%s\n%s\n%s\n"
       }
 
-      # Test if the file notification option is available?
+      # @param [Hash] opts some options
+      # @option opts [Boolean] path the path to a file where Guard notification
+      #   results will be written
       #
-      # @param [Boolean] silent true if no error messages should be shown
-      # @param [Hash] options notifier options
-      # @return [Boolean] the availability status
-      #
-      def available?(silent = false, options = {})
-        options.has_key?(:path)
+      def self.available?(opts = {})
+        super
+        opts.has_key?(:path)
       end
 
-      # Write the notification to a file. By default it writes type, title, and
-      # message separated by newlines.
+      # Writes the notification to a file. By default it writes type, title,
+      # and message separated by newlines.
       #
-      # @param [String] type the notification type. Either 'success', 'pending', 'failed' or 'notify'
-      # @param [String] title the notification title
       # @param [String] message the notification message body
-      # @param [String] image the path to the notification image
-      # @param [Hash] options additional notification library options
-      # @option options [String] format printf style format for file contents
-      # @option options [String] path the path of where to write the file
+      # @param [Hash] opts additional notification library options
+      # @option opts [String] type the notification type. Either 'success',
+      #   'pending', 'failed' or 'notify'
+      # @option opts [String] title the notification title
+      # @option opts [String] image the path to the notification image
+      # @option opts [String] format printf style format for file contents
+      # @option opts [String] path the path of where to write the file
       #
-      def notify(type, title, message, image, options = {})
-        if options[:path]
-          format = options.fetch(:format, DEFAULTS[:format])
+      def notify(message, opts = {})
+        normalize_standard_options!(opts)
 
-          _write(options[:path], format % [type, title, message])
+        if opts[:path]
+          format = opts.fetch(:format, DEFAULTS[:format])
+
+          _write(opts[:path], format % [opts[:type], opts[:title], message])
         else
           ::Guard::UI.error ':file notifier requires a :path option'
         end
@@ -50,6 +52,7 @@ module Guard
       def _write(path, contents)
         File.write(path, contents)
       end
+
     end
 
   end

--- a/lib/guard/notifiers/gntp.rb
+++ b/lib/guard/notifiers/gntp.rb
@@ -1,13 +1,13 @@
-require 'rbconfig'
-require 'guard/ui'
+require 'guard/notifiers/base'
 
 module Guard
   module Notifier
 
-    # System notifications using the [ruby_gntp](https://github.com/snaka/ruby_gntp) gem.
+    # System notifications using the
+    # [ruby_gntp](https://github.com/snaka/ruby_gntp) gem.
     #
-    # This gem is available for OS X, Linux and Windows and sends system notifications to
-    # the following system notification frameworks through the
+    # This gem is available for OS X, Linux and Windows and sends system
+    # notifications to the following system notification frameworks through the
     # [Growl Network Transport Protocol](http://www.growlforwindows.com/gfw/help/gntp.aspx):
     #
     # * [Growl](http://growl.info)
@@ -26,93 +26,87 @@ module Guard
     # @example Add the `:gntp` notifier with configuration options to your `Guardfile`
     #   notification :gntp, :sticky => true, :host => '192.168.1.5', :password => 'secret'
     #
-    module GNTP
-      extend self
+    class GNTP < Base
 
-      # Default options for the ruby gtnp gem
+      # Default options for the ruby gtnp notifications.
       DEFAULTS = {
-        :sticky   => false,
+        :sticky => false
+      }
+
+      # Default options for the ruby gtnp client.
+      CLIENT_DEFAULTS = {
         :host     => '127.0.0.1',
         :password => '',
         :port     => 23053
       }
 
-      # Is this notifier already registered
-      #
-      # @return [Boolean] registration status
-      #
-      def registered?
-        @registered ||= false
+      def self.supported_hosts
+        %w[darwin linux freebsd openbsd sunos solaris mswin mingw cygwin]
       end
 
-      # Mark the notifier as registered.
-      #
-      def registered!
-        @registered = true
+      def self.gem_name
+        'ruby_gntp'
       end
 
-      # Test if the notification library is available.
-      #
-      # @param [Boolean] silent true if no error messages should be shown
-      # @param [Hash] options notifier options
-      # @return [Boolean] the availability status
-      #
-      def available?(silent = false, options = {})
-        if RbConfig::CONFIG['host_os'] =~ /darwin|linux|freebsd|openbsd|sunos|solaris|mswin|mingw|cygwin/
-          require 'ruby_gntp'
-          true
-
-        else
-          ::Guard::UI.error 'The :gntp notifier runs only on Mac OS X, Linux, FreeBSD, OpenBSD, Solaris and Windows.' unless silent
-          false
-        end
-
-      rescue LoadError
-        ::Guard::UI.error "Please add \"gem 'ruby_gntp'\" to your Gemfile and run Guard with \"bundle exec\"." unless silent
-        false
+      def self.available?(opts = {})
+        super
+        require_gem_safely(opts)
       end
 
-      # Show a system notification.
+      # Shows a system notification.
       #
-      # @param [String] type the notification type. Either 'success', 'pending', 'failed' or 'notify'
-      # @param [String] title the notification title
       # @param [String] message the notification message body
-      # @param [String] image the path to the notification image
-      # @param [Hash] options additional notification library options
-      # @option options [String] host the hostname or IP address to which to send a remote notification
-      # @option options [String] password the password used for remote notifications
-      # @option options [Integer] port the port to send a remote notification
-      # @option options [Boolean] sticky make the notification sticky
+      # @param [Hash] opts additional notification library options
+      # @option opts [String] type the notification type. Either 'success',
+      #   'pending', 'failed' or 'notify'
+      # @option opts [String] title the notification title
+      # @option opts [String] image the path to the notification image
+      # @option opts [String] host the hostname or IP address to which to send
+      #   a remote notification
+      # @option opts [String] password the password used for remote
+      #   notifications
+      # @option opts [Integer] port the port to send a remote notification
+      # @option opts [Boolean] sticky make the notification sticky
       #
-      def notify(type, title, message, image, options = {})
-        require 'ruby_gntp'
+      def notify(message, opts = {})
+        self.class.require_gem_safely
+        normalize_standard_options!(opts)
 
-        options = DEFAULTS.merge(options)
+        opts = DEFAULTS.merge(
+          :name  => opts.delete(:type).to_s,
+          :text  => message,
+          :icon  => opts.delete(:image)
+        ).merge(opts)
 
-        gntp = ::GNTP.new('Guard', options.delete(:host), options.delete(:password), options.delete(:port))
+        _client(opts).notify(opts)
+      end
 
-        unless registered?
-          gntp.register({
-              :app_icon => File.expand_path(File.join(__FILE__, '..', '..', '..', '..', 'images', 'guard.png')),
-              :notifications => [
-                  { :name => 'notify', :enabled => true },
-                  { :name => 'failed', :enabled => true },
-                  { :name => 'pending', :enabled => true },
-                  { :name => 'success', :enabled => true }
-              ]
-          })
+      private
 
-          registered!
+      def _register!(gntp_client)
+        gntp_client.register(
+          :app_icon => images_path.join('guard.png').to_s,
+          :notifications => [
+            { :name => 'notify', :enabled => true },
+            { :name => 'failed', :enabled => true },
+            { :name => 'pending', :enabled => true },
+            { :name => 'success', :enabled => true }
+          ]
+        )
+      end
+
+      def _client(opts = {})
+        @_client ||= begin
+          gntp = ::GNTP.new('Guard',
+                            opts.delete(:host) { CLIENT_DEFAULTS[:host] },
+                            opts.delete(:password) { CLIENT_DEFAULTS[:password] },
+                            opts.delete(:port) { CLIENT_DEFAULTS[:port] })
+          _register!(gntp)
+          gntp
         end
-
-        gntp.notify(options.merge({
-            :name  => type,
-            :title => title,
-            :text  => message,
-            :icon  => image
-        }))
       end
 
     end
+
   end
 end

--- a/lib/guard/notifiers/growl_notify.rb
+++ b/lib/guard/notifiers/growl_notify.rb
@@ -1,5 +1,4 @@
-require 'rbconfig'
-require 'guard/ui'
+require 'guard/notifiers/base'
 
 module Guard
   module Notifier
@@ -20,74 +19,70 @@ module Guard
     # @example Add the `:growl_notify` notifier with configuration options to your `Guardfile`
     #   notification :growl_notify, :sticky => true
     #
-    module GrowlNotify
-      extend self
+    class GrowlNotify < Base
 
-      # Default options for growl_notify gem
+      # Default options for the growl_notify notifications.
       DEFAULTS = {
         :sticky   => false,
         :priority => 0
       }
 
-      # Test if the notification library is available.
+      def self.supported_hosts
+        %w[darwin]
+      end
+
+      def self.available?(opts = {})
+        super
+        _register!(opts) if require_gem_safely(opts)
+      end
+
+      # Shows a system notification.
       #
-      # @param [Boolean] silent true if no error messages should be shown
-      # @param [Hash] options notifier options
-      # @return [Boolean] the availability status
+      # @param [String] message the notification message body
+      # @param [Hash] opts additional notification library options
+      # @option opts [String] type the notification type. Either 'success',
+      #   'pending', 'failed' or 'notify'
+      # @option opts [String] title the notification title
+      # @option opts [String] image the path to the notification image
+      # @option opts [Boolean] sticky if the message should stick to the screen
+      # @option opts [Integer] priority the importance of message from -2 (very
+      #   low) to 2 (emergency)
       #
-      def available?(silent = false, options = {})
-        if RbConfig::CONFIG['host_os'] =~ /darwin/
-          require 'growl_notify'
+      def notify(message, opts = {})
+        self.class.require_gem_safely
+        normalize_standard_options!(opts)
 
-          begin
-            if ::GrowlNotify.application_name != 'Guard'
-              ::GrowlNotify.config do |c|
-                c.notifications         = %w(success pending failed notify)
-                c.default_notifications = 'notify'
-                c.application_name      = 'Guard'
-              end
-            end
+        opts = DEFAULTS.merge(
+          :application_name => 'Guard',
+          :with_name        => opts.delete(:type).to_s,
+          :description      => message,
+          :icon             => opts.delete(:image)
+        ).merge(opts)
 
-            true
+        ::GrowlNotify.send_notification(opts)
+      end
 
-          rescue ::GrowlNotify::GrowlNotFound
-            ::Guard::UI.error 'Please install Growl from http://growl.info' unless silent
-            false
+      # @private
+      #
+      def self._register!(options)
+        if ::GrowlNotify.application_name != 'Guard'
+          ::GrowlNotify.config do |c|
+            c.notifications         = %w(success pending failed notify)
+            c.default_notifications = 'notify'
+            c.application_name      = 'Guard'
           end
-
-        else
-          ::Guard::UI.error 'The :growl_notify notifier runs only on Mac OS X.' unless silent
-          false
         end
 
-      rescue LoadError, NameError
-        ::Guard::UI.error "Please add \"gem 'growl_notify'\" to your Gemfile and run Guard with \"bundle exec\"." unless silent
+        true
+
+      rescue ::GrowlNotify::GrowlNotFound
+        unless options[:silent]
+          ::Guard::UI.error 'Please install Growl from http://growl.info'
+        end
         false
       end
 
-      # Show a system notification.
-      #
-      # @param [String] type the notification type. Either 'success', 'pending', 'failed' or 'notify'
-      # @param [String] title the notification title
-      # @param [String] message the notification message body
-      # @param [String] image the path to the notification image
-      # @param [Hash] options additional notification library options
-      # @option options [Boolean] sticky if the message should stick to the screen
-      # @option options [Integer] priority the importance of message from -2 (very low) to 2 (emergency)
-      #
-      def notify(type, title, message, image, options = {})
-        require 'growl_notify'
-
-        ::GrowlNotify.send_notification(DEFAULTS.merge(options).merge({
-            :application_name => 'Guard',
-            :with_name        => type,
-            :title            => title,
-            :description      => message,
-            :icon             => image
-        }))
-      end
-
     end
+
   end
 end
-

--- a/lib/guard/notifiers/libnotify.rb
+++ b/lib/guard/notifiers/libnotify.rb
@@ -1,12 +1,13 @@
-require 'rbconfig'
-require 'guard/ui'
+require 'guard/notifiers/base'
 
 module Guard
   module Notifier
 
-    # System notifications using the [libnotify](https://github.com/splattael/libnotify) gem.
+    # System notifications using the
+    # [libnotify](https://github.com/splattael/libnotify) gem.
     #
-    # This gem is available for Linux, FreeBSD, OpenBSD and Solaris and sends system notifications to
+    # This gem is available for Linux, FreeBSD, OpenBSD and Solaris and sends
+    # system notifications to
     # Gnome [libnotify](http://developer.gnome.org/libnotify):
     #
     # @example Add the `libnotify` gem to your `Gemfile`
@@ -20,60 +21,50 @@ module Guard
     # @example Add the `:libnotify` notifier with configuration options to your `Guardfile`
     #   notification :libnotify, :timeout => 5, :transient => true, :append => false, :urgency => :critical
     #
-    module Libnotify
-      extend self
+    class Libnotify < Base
 
-      # Default options for libnotify gem
+      # Default options for the libnotify notifications.
       DEFAULTS = {
         :transient => false,
         :append    => true,
         :timeout   => 3
       }
 
-      # Test if the notification library is available.
-      #
-      # @param [Boolean] silent true if no error messages should be shown
-      # @param [Hash] options notifier options
-      # @return [Boolean] the availability status
-      #
-      def available?(silent = false, options = {})
-        if RbConfig::CONFIG['host_os'] =~ /linux|freebsd|openbsd|sunos|solaris/
-          require 'libnotify'
-
-          true
-
-        else
-          ::Guard::UI.error 'The :libnotify notifier runs only on Linux, FreeBSD, OpenBSD and Solaris.' unless silent
-          false
-        end
-
-      rescue LoadError
-        ::Guard::UI.error "Please add \"gem 'libnotify'\" to your Gemfile and run Guard with \"bundle exec\"." unless silent
-        false
+      def self.supported_hosts
+        %w[linux freebsd openbsd sunos solaris]
       end
 
-      # Show a system notification.
+      def self.available?(opts = {})
+        super
+        require_gem_safely(opts)
+      end
+
+      # Shows a system notification.
       #
-      # @param [String] type the notification type. Either 'success', 'pending', 'failed' or 'notify'
-      # @param [String] title the notification title
       # @param [String] message the notification message body
-      # @param [String] image the path to the notification image
-      # @param [Hash] options additional notification library options
-      # @option options [Boolean] transient keep the notifications around after display
-      # @option options [Boolean] append append onto existing notification
-      # @option options [Number, Boolean] timeout the number of seconds to display (1.5 (s), 1000 (ms), false)
+      # @param [Hash] opts additional notification library options
+      # @option opts [String] type the notification type. Either 'success',
+      #   'pending', 'failed' or 'notify'
+      # @option opts [String] title the notification title
+      # @option opts [String] image the path to the notification image
+      # @option opts [Boolean] transient keep the notifications around after
+      #   display
+      # @option opts [Boolean] append append onto existing notification
+      # @option opts [Number, Boolean] timeout the number of seconds to display
+      #   (1.5 (s), 1000 (ms), false)
       #
-      def notify(type, title, message, image, options = {})
-        require 'libnotify'
+      def notify(message, opts = {})
+        self.class.require_gem_safely
+        normalize_standard_options!(opts)
 
-        options = DEFAULTS.merge(options).merge({
-          :summary   => title,
+        opts = DEFAULTS.merge(
+          :summary   => opts.delete(:title),
+          :icon_path => opts.delete(:image),
           :body      => message,
-          :icon_path => image
-        )
-        options[:urgency] ||= _libnotify_urgency(type)
+          :urgency   => _libnotify_urgency(opts.delete(:type))
+        ).merge(opts)
 
-        ::Libnotify.show(options)
+        ::Libnotify.show(opts)
       end
 
       private
@@ -94,5 +85,6 @@ module Guard
       end
 
     end
+
   end
 end

--- a/lib/guard/notifiers/notifysend.rb
+++ b/lib/guard/notifiers/notifysend.rb
@@ -1,5 +1,4 @@
-require 'rbconfig'
-require 'guard/ui'
+require 'guard/notifiers/base'
 
 module Guard
   module Notifier
@@ -10,54 +9,53 @@ module Guard
     # @example Add the `:notifysend` notifier to your `Guardfile`
     #   notification :notifysend
     #
-    module NotifySend
-      extend self
+    class NotifySend < Base
 
-      # Default options for the notify-send program
+      # Default options for the notify-send notifications.
       DEFAULTS = {
         :t => 3000, # Default timeout is 3000ms
         :h => 'int:transient:1' # Automatically close the notification
       }
 
-      # Full list of options supported by notify-send
+      # Full list of options supported by notify-send.
       SUPPORTED = [:u, :t, :i, :c, :h]
 
-      # Test if the notification program is available.
-      #
-      # @param [Boolean] silent true if no error messages should be shown
-      # @param [Hash] options notifier options
-      # @return [Boolean] the availability status
-      #
-      def available?(silent = false, options = {})
-        if (RbConfig::CONFIG['host_os'] =~ /linux|freebsd|openbsd|sunos|solaris/) and (not `which notify-send`.empty?)
-          true
-        else
-          ::Guard::UI.error 'The :notifysend notifier runs only on Linux, FreeBSD, OpenBSD and Solaris with the libnotify-bin package installed.' unless silent
-          false
-        end
+      def self.supported_hosts
+        %w[linux freebsd openbsd sunos solaris]
       end
 
-      # Show a system notification.
-      #
-      # @param [String] type the notification type. Either 'success', 'pending', 'failed' or 'notify'
-      # @param [String] title the notification title
-      # @param [String] message the notification message body
-      # @param [String] image the path to the notification image
-      # @param [Hash] options additional notification library options
-      # @option options [String] c the notification category
-      # @option options [Number] t the number of milliseconds to display (1000, 3000)
-      #
-      def notify(type, title, message, image, options = {})
-        command = "notify-send '#{title}' '#{message}'"
-        options = DEFAULTS.merge(options).merge(:i => image)
-        options[:u] ||= _notifysend_urgency(type)
+      def self.available?(opts = {})
+        super
+        _register!(opts)
+      end
 
-        system(_to_command_string(command, SUPPORTED, options))
+      # Shows a system notification.
+      #
+      # @param [String] message the notification message body
+      # @param [Hash] opts additional notification library options
+      # @option opts [String] type the notification type. Either 'success',
+      #   'pending', 'failed' or 'notify'
+      # @option opts [String] title the notification title
+      # @option opts [String] image the path to the notification image
+      # @option opts [String] c the notification category
+      # @option opts [Number] t the number of milliseconds to display (1000,
+      #   3000)
+      #
+      def notify(message, opts = {})
+        normalize_standard_options!(opts)
+
+        command = "notify-send '#{opts.delete(:title)}' '#{message}'"
+        opts = DEFAULTS.merge(
+          :i => opts.delete(:image),
+          :u => _notifysend_urgency(opts.delete(:type))
+        ).merge(opts)
+
+        system(_to_command_string(command, SUPPORTED, opts))
       end
 
       private
 
-      # Convert Guards notification type to the best matching
+      # Converts Guards notification type to the best matching
       # notify-send urgency.
       #
       # @param [String] type the Guard notification type
@@ -67,18 +65,42 @@ module Guard
         { 'failed' => 'normal', 'pending' => 'low' }.fetch(type, 'low')
       end
 
-      # Build a shell command out of a command string and option hash.
+      # Builds a shell command out of a command string and option hash.
       #
       # @param [String] command the command execute
       # @param [Array] supported list of supported option flags
       # @param [Hash] options additional command options
-      # @return [String] the command and its options converted to a shell command.
+      # @return [String] the command and its options converted to a shell
+      #   command.
       #
       def _to_command_string(command, supported, options = {})
         options.reduce(command) do |cmd, (flag, value)|
           supported.include?(flag) ? cmd + " -#{ flag } '#{ value }'" : cmd
         end
       end
+
+      # @private
+      #
+      # @return [Boolean] whether or not the notify-send binary is available
+      #
+      def self._notifysend_binary_available?
+        !`which notify-send`.empty?
+      end
+
+      # @private
+      #
+      def self._register!(options)
+        unless _notifysend_binary_available?
+          unless options[:silent]
+            ::Guard::UI.error 'The :notifysend notifier runs only on Linux, FreeBSD, OpenBSD and Solaris with the libnotify-bin package installed.'
+          end
+          false
+        end
+
+        true
+      end
+
     end
+
   end
 end

--- a/lib/guard/notifiers/terminal_notifier.rb
+++ b/lib/guard/notifiers/terminal_notifier.rb
@@ -1,12 +1,14 @@
-require 'guard/ui'
+require 'guard/notifiers/base'
 
 module Guard
   module Notifier
 
-    # System notifications using the [terminal-notifier-guard](https://github.com/Springest/terminal-notifier-guard gem.
+    # System notifications using the
+    # [terminal-notifier-guard](https://github.com/Springest/terminal-notifier-guard
+    # gem.
     #
-    # This gem is available for OS X 10.8 Mountain Lion and sends notifications to the OS X
-    # notification center.
+    # This gem is available for OS X 10.8 Mountain Lion and sends notifications
+    # to the OS X notification center.
     #
     # @example Add the `terminal-notifier-guard` gem to your `Gemfile`
     #   group :development
@@ -19,49 +21,59 @@ module Guard
     # @example Add the `:terminal_notifier` notifier with configuration options to your `Guardfile`
     #   notification :terminal_notifier, app_name: "MyApp"
     #
-    module TerminalNotifier
-      extend self
+    class TerminalNotifier < Base
 
-      # Test if the notification library is available.
-      #
-      # @param [Boolean] silent true if no error messages should be shown
-      # @param [Hash] options notifier options
-      # @return [Boolean] the availability status
-      #
-      def available?(silent = false, options = {})
-        require 'terminal-notifier-guard'
+      def self.supported_hosts
+        %w[darwin]
+      end
 
+      def self.gem_name
+        'terminal-notifier-guard'
+      end
+
+      def self.available?(opts = {})
+        super
+        _register!(opts) if require_gem_safely(opts)
+      end
+
+      # Shows a system notification.
+      #
+      # @param [String] message the notification message body
+      # @param [Hash] opts additional notification library options
+      # @option opts [String] type the notification type. Either 'success',
+      #   'pending', 'failed' or 'notify'
+      # @option opts [String] title the notification title
+      # @option opts [String] image the path to the notification image (ignored)
+      # @option opts [String] app_name name of your app
+      # @option opts [String] execute a command
+      # @option opts [String] activate an app bundle
+      # @option opts [String] open some url or file
+      #
+      def notify(message, opts = {})
+        self.class.require_gem_safely
+        title = opts[:title]
+        normalize_standard_options!(opts)
+
+        opts.delete(:image)
+        opts[:title] = title || [opts.delete(:app_name) { 'Guard' }, opts[:type].downcase.capitalize].join(' ')
+
+        ::TerminalNotifier::Guard.execute(false, opts.merge(:message => message))
+      end
+
+      # @private
+      #
+      def self._register!(options)
         if ::TerminalNotifier::Guard.available?
           true
         else
-          ::Guard::UI.error 'The :terminal_notifier only runs on Mac OS X 10.8 and later.' unless silent
+          unless options[:silent]
+            ::Guard::UI.error 'The :terminal_notifier only runs on Mac OS X 10.8 and later.'
+          end
           false
         end
-
-      rescue LoadError, NameError
-        ::Guard::UI.error "Please add \"gem 'terminal-notifier-guard'\" to your Gemfile and run Guard with \"bundle exec\"." unless silent
-        false
       end
 
-      # Show a system notification.
-      #
-      # @param [String] type the notification type. Either 'success', 'pending', 'failed' or 'notify'
-      # @param [String] title the notification title
-      # @param [String] message the notification message body
-      # @param [String] image the path to the notification image (ignored)
-      # @param [Hash] options additional notification library options
-      # @option options [String] app_name name of your app
-      # @option options [String] execute a command
-      # @option options [String] activate an app bundle
-      # @option options [String] open some url or file
-      #
-      def notify(type, title, message, image, options = {})
-        require 'terminal-notifier-guard'
-        options[:title] = title || [options[:app_name] || 'Guard', type.downcase.capitalize].join(' ')
-        options.merge!(:type => type.to_sym, :message => message)
-        options.delete :app_name if options[:app_name]
-        ::TerminalNotifier::Guard.execute(false, options)
-      end
     end
+
   end
 end

--- a/lib/guard/notifiers/terminal_title.rb
+++ b/lib/guard/notifiers/terminal_title.rb
@@ -1,31 +1,29 @@
-# Module for notifying test result to terminal title
+require 'guard/notifiers/base'
+
 module Guard
   module Notifier
-    module TerminalTitle
-      extend self
 
-      # Test if the notification library is available.
-      #
-      # @param [Boolean] silent true if no error messages should be shown
-      # @param [Hash] options notifier options
-      # @return [Boolean] the availability status
-      #
-      def available?(silent = false, options = {})
-        true
-      end
+    # Shows system notifications in the terminal title bar.
+    #
+    class TerminalTitle < Base
 
-      # Show a system notification.
+      # Shows a system notification.
       #
-      # @param [String] type the notification type. Either 'success', 'pending', 'failed' or 'notify'
-      # @param [String] title the notification title
-      # @param [String] message the notification message body
-      # @param [String] image the path to the notification image
-      # @param [Hash] options additional notification library options
+      # @param [Hash] opts additional notification library options
+      # @option opts [String] message the notification message body
+      # @option opts [String] type the notification type. Either 'success',
+      #   'pending', 'failed' or 'notify'
+      # @option opts [String] title the notification title
       #
-      def notify(type, title, message, image, options = {})
+      def notify(message, opts = {})
+        normalize_standard_options!(opts)
+
         first_line = message.sub(/^\n/, '').sub(/\n.*/m, '')
-        puts("\e]2;[#{ title }] #{ first_line }\a")
+
+        puts "\e]2;[#{ opts[:title] }] #{ first_line }\a"
       end
+
     end
+
   end
 end

--- a/lib/guard/notifiers/tmux.rb
+++ b/lib/guard/notifiers/tmux.rb
@@ -1,3 +1,5 @@
+require 'guard/notifiers/base'
+
 module Guard
   module Notifier
 
@@ -13,10 +15,9 @@ module Guard
     # @example Customize the tmux status colored for notifications
     #   notification :tmux, :color_location => 'status-right-bg'
     #
-    module Tmux
-      extend self
+    class Tmux < Base
 
-      # Default options for Tmux
+      # Default options for the tmux notifications.
       DEFAULTS = {
         :client                 => 'tmux',
         :tmux_environment       => 'TMUX',
@@ -32,76 +33,95 @@ module Guard
         :color_location         => 'status-left-bg'
       }
 
-      # Test if currently running in a Tmux session
-      #
-      # @param [Boolean] silent true if no error messages should be shown
-      # @param [Hash] options notifier options
-      # @return [Boolean] the availability status
-      #
-      def available?(silent = false, options = {})
-        if ENV[options.fetch(:tmux_environment, DEFAULTS[:tmux_environment])].nil?
-          ::Guard::UI.error 'The :tmux notifier runs only on when Guard is executed inside of a tmux session.' unless silent
+      def self.available?(opts = {})
+        super
+
+        if ENV[opts.fetch(:tmux_environment, DEFAULTS[:tmux_environment])].nil?
+          unless opts[:silent]
+            ::Guard::UI.error 'The :tmux notifier runs only on when Guard is executed inside of a tmux session.'
+          end
           false
         else
           true
         end
       end
 
-      # Show a system notification. By default, the Tmux notifier only makes use of a color based
-      # notification, changing the background color of the `color_location` to the color defined
-      # in either the `success`, `failed`, `pending` or `default`, depending on the notification type.
-      # If you also want display a text message, you have to enable it explicit by setting `display_message`
-      # to `true`.
+      # Shows a system notification.
       #
-      # @param [String] type the notification type. Either 'success', 'pending', 'failed' or 'notify'
+      # By default, the Tmux notifier only makes
+      # use of a color based notification, changing the background color of the
+      # `color_location` to the color defined in either the `success`,
+      # `failed`, `pending` or `default`, depending on the notification type.
+      # If you also want display a text message, you have to enable it explicit
+      # by setting `display_message` to `true`.
+      #
       # @param [String] title the notification title
-      # @param [String] message the notification message body
-      # @param [String] image the path to the notification image
-      # @param [Hash] options additional notification library options
-      # @option options [String] color_location the location where to draw the color notification
-      # @option options [Boolean] display_message whether to display a message or not
+      # @param [Hash] opts additional notification library options
+      # @option opts [String] type the notification type. Either 'success',
+      #   'pending', 'failed' or 'notify'
+      # @option opts [String] message the notification message body
+      # @option opts [String] image the path to the notification image
+      # @option opts [String] color_location the location where to draw the
+      #   color notification
+      # @option opts [Boolean] display_message whether to display a message
+      #   or not
       #
-      def notify(type, title, message, image, options = {})
-        color = tmux_color(type, options)
-        color_location = options[:color_location] || DEFAULTS[:color_location]
+      def notify(message, opts = {})
+        normalize_standard_options!(opts)
+        opts.delete(:image)
 
-        run_client "set #{ color_location } #{ color }"
+        color_location = opts.fetch(:color_location, DEFAULTS[:color_location])
+        color = tmux_color(opts[:type], opts)
 
-        show_message = options[:display_message] || DEFAULTS[:display_message]
-        display_message(type, title, message, options) if show_message
+        _run_client "set #{ color_location } #{ color }"
+
+        if opts.fetch(:display_message, DEFAULTS[:display_message])
+          display_message(opts.delete(:type).to_s, opts.delete(:title), message, opts)
+        end
       end
 
-      # Display a message in the status bar of tmux.
+      # Displays a message in the status bar of tmux.
       #
-      # @param [String] type the notification type. Either 'success', 'pending', 'failed' or 'notify'
+      # @param [String] type the notification type. Either 'success',
+      #   'pending', 'failed' or 'notify'
       # @param [String] title the notification title
       # @param [String] message the notification message body
       # @param [Hash] options additional notification library options
-      # @option options [Integer] timeout the amount of seconds to show the message in the status bar
-      # @option options [String] success_message_format a string to use as formatter for the success message.
-      # @option options [String] failed_message_format a string to use as formatter for the failed message.
-      # @option options [String] pending_message_format a string to use as formatter for the pending message.
-      # @option options [String] default_message_format a string to use as formatter when no format per type is defined.
-      # @option options [String] success_message_color the success notification foreground color name.
-      # @option options [String] failed_message_color the failed notification foreground color name.
-      # @option options [String] pending_message_color the pending notification foreground color name.
-      # @option options [String] default_message_color a notification foreground color to use when no color per type is defined.
-      # @option options [String] line_separator a string to use instead of a line-break.
+      # @option options [Integer] timeout the amount of seconds to show the
+      #   message in the status bar
+      # @option options [String] success_message_format a string to use as
+      #   formatter for the success message.
+      # @option options [String] failed_message_format a string to use as
+      #   formatter for the failed message.
+      # @option options [String] pending_message_format a string to use as
+      #   formatter for the pending message.
+      # @option options [String] default_message_format a string to use as
+      #   formatter when no format per type is defined.
+      # @option options [String] success_message_color the success notification
+      #   foreground color name.
+      # @option options [String] failed_message_color the failed notification
+      #   foreground color name.
+      # @option options [String] pending_message_color the pending notification
+      #   foreground color name.
+      # @option options [String] default_message_color a notification
+      #   foreground color to use when no color per type is defined.
+      # @option options [String] line_separator a string to use instead of a
+      #   line-break.
       #
-      def display_message(type, title, message, options = {})
-          message_format = options["#{ type }_message_format".to_sym] || options[:default_message_format] || DEFAULTS[:default_message_format]
-          message_color = options["#{ type }_message_color".to_sym] || options[:default_message_color] || DEFAULTS[:default_message_color]
-          display_time = options[:timeout] || DEFAULTS[:timeout]
-          separator = options[:line_separator] || DEFAULTS[:line_separator]
+      def display_message(type, title, message, opts = {})
+        message_format = opts.fetch("#{ type }_message_format".to_sym, opts.fetch(:default_message_format, DEFAULTS[:default_message_format]))
+        message_color = opts.fetch("#{ type }_message_color".to_sym, opts.fetch(:default_message_color, DEFAULTS[:default_message_color]))
+        display_time = opts.fetch(:timeout, DEFAULTS[:timeout])
+        separator = opts.fetch(:line_separator, DEFAULTS[:line_separator])
 
-          color = tmux_color type, options
-          formatted_message = message.split("\n").join(separator)
-          display_message = message_format % [title, formatted_message]
+        color = tmux_color type, opts
+        formatted_message = message.split("\n").join(separator)
+        display_message = message_format % [title, formatted_message]
 
-          run_client "set display-time #{ display_time * 1000 }"
-          run_client "set message-fg #{ message_color }"
-          run_client "set message-bg #{ color }"
-          run_client "display-message '#{ display_message }'"
+        _run_client "set display-time #{ display_time * 1000 }"
+        _run_client "set message-fg #{ message_color }"
+        _run_client "set message-bg #{ color }"
+        _run_client "display-message '#{ display_message }'"
       end
 
       # Get the Tmux color for the notification type.
@@ -110,55 +130,51 @@ module Guard
       # @param [String] type the notification type
       # @return [String] the name of the emacs color
       #
-      def tmux_color(type, options = {})
-        case type
-        when 'success'
-          options[:success] || DEFAULTS[:success]
-        when 'failed'
-          options[:failed]  || DEFAULTS[:failed]
-        when 'pending'
-          options[:pending] || DEFAULTS[:pending]
-        else
-          options[:default] || DEFAULTS[:default]
-        end
+      def tmux_color(type, opts = {})
+        type = type.to_sym
+        type = :default unless [:success, :failed, :pending].include?(type)
+
+        opts.fetch(type, DEFAULTS[type])
       end
 
       # Notification starting, save the current Tmux settings
       # and quiet the Tmux output.
       #
-      def turn_on(options = {})
+      def turn_on
         unless @options_stored
-          reset_options_store
-
+          _reset_options_store
           `#{ DEFAULTS[:client] } show`.each_line do |line|
             option, _, setting = line.chomp.partition(' ')
-            @options_store[option] = setting
+            options_store[option] = setting
           end
 
           @options_stored = true
         end
 
-        run_client "set quiet on"
+        _run_client 'set quiet on'
       end
 
       # Notification stopping. Restore the previous Tmux state
       # if available (existing options are restored, new options
       # are unset) and unquiet the Tmux output.
       #
-      def turn_off(options = {})
+      def turn_off
         if @options_stored
           @options_store.each do |key, value|
             if value
-              run_client "set #{ key } #{ value }"
+              _run_client "set #{ key } #{ value }"
             else
-              run_client "set -u #{ key }"
+              _run_client "set -u #{ key }"
             end
           end
-
-          reset_options_store
+          _reset_options_store
         end
 
-        run_client 'set quiet off'
+        _run_client 'set quiet off'
+      end
+
+      def options_store
+        @options_store ||= {}
       end
 
       private
@@ -168,13 +184,13 @@ module Guard
         super
       end
 
-      def run_client(args)
+      def _run_client(args)
         system("#{ DEFAULTS[:client] } #{args}")
       end
 
       # Reset the internal Tmux options store defaults.
       #
-      def reset_options_store
+      def _reset_options_store
         @options_stored = false
         @options_store = {
           'status-left-bg'  => nil,
@@ -188,5 +204,6 @@ module Guard
       end
 
     end
+
   end
 end

--- a/spec/guard/dsl_spec.rb
+++ b/spec/guard/dsl_spec.rb
@@ -100,13 +100,13 @@ describe Guard::Dsl do
     disable_user_config
 
     it 'adds a notification to the notifier' do
-      ::Guard::Notifier.should_receive(:add_notification).with(:growl, {}, false)
+      ::Guard::Notifier.should_receive(:add_notifier).with(:growl, { :silent => false })
       described_class.evaluate_guardfile(:guardfile_contents => 'notification :growl')
     end
 
     it 'adds multiple notification to the notifier' do
-      ::Guard::Notifier.should_receive(:add_notification).with(:growl, {}, false)
-      ::Guard::Notifier.should_receive(:add_notification).with(:ruby_gntp, { :host => '192.168.1.5' }, false)
+      ::Guard::Notifier.should_receive(:add_notifier).with(:growl, { :silent => false })
+      ::Guard::Notifier.should_receive(:add_notifier).with(:ruby_gntp, { :host => '192.168.1.5', :silent => false })
       described_class.evaluate_guardfile(:guardfile_contents => "notification :growl\nnotification :ruby_gntp, :host => '192.168.1.5'")
     end
   end

--- a/spec/guard/guardfile/evaluator_spec.rb
+++ b/spec/guard/guardfile/evaluator_spec.rb
@@ -194,6 +194,7 @@ describe Guard::Guardfile::Evaluator do
       guardfile_evaluator.stub(:_instance_eval_guardfile)
       ::Guard.runner.stub(:run)
     end
+    let(:growl) { { :name => :growl, :options => {} } }
 
     it 'evaluates the Guardfile' do
       guardfile_evaluator.should_receive(:evaluate_guardfile)
@@ -221,12 +222,12 @@ describe Guard::Guardfile::Evaluator do
 
     it 'clears the notifications' do
        ::Guard::Notifier.turn_off
-       ::Guard::Notifier.notifications = [{ :name => :growl }]
-       ::Guard::Notifier.notifications.should_not be_empty
+       ::Guard::Notifier.notifiers = [growl]
+       ::Guard::Notifier.notifiers.should_not be_empty
 
        guardfile_evaluator.reevaluate_guardfile
 
-       ::Guard::Notifier.notifications.should eq []
+       ::Guard::Notifier.notifiers.should be_empty
     end
 
     it 'removes the cached Guardfile content' do

--- a/spec/guard/notifier_spec.rb
+++ b/spec/guard/notifier_spec.rb
@@ -1,32 +1,39 @@
 require 'spec_helper'
 
 describe Guard::Notifier do
+  let(:gntp)  { { :name => :gntp, :options => {} } }
+  let(:growl) { { :name => :growl, :options => {} } }
+  let(:gntp_object) { double('GNTP').as_null_object }
+  let(:growl_object) { double('Growl').as_null_object }
 
   describe '.turn_on' do
     context 'with configured notifications' do
       before do
-        Guard::Notifier.notifications = [{ :name => :gntp, :options => {} }]
+        Guard::Notifier.notifiers = [gntp]
       end
 
       it 'shows the used notifications' do
         Guard::UI.should_receive(:info).with 'Guard uses GNTP to send notifications.'
+
         Guard::Notifier.turn_on
       end
 
       it 'enables the notifications' do
         Guard::Notifier.turn_on
+
         Guard::Notifier.should be_enabled
       end
 
       it 'turns on the defined notification module' do
-        ::Guard::Notifier::GNTP.should_receive(:turn_on)
+        Guard::Notifier::GNTP.should_receive(:turn_on)
+
         Guard::Notifier.turn_on
       end
     end
 
-    context 'without configured notifications' do
+    context 'without configured notifiers' do
       before do
-        Guard::Notifier.notifications = []
+        Guard::Notifier.clear_notifiers
       end
 
       context 'when notifications are globally enabled' do
@@ -36,38 +43,40 @@ describe Guard::Notifier do
         end
 
         it 'tries to add each available notification silently' do
-          Guard::Notifier.should_receive(:add_notification).with(:gntp, {}, true).and_return false
-          Guard::Notifier.should_receive(:add_notification).with(:growl, {}, true).and_return false
-          Guard::Notifier.should_receive(:add_notification).with(:growl_notify, {}, true).and_return false
-          Guard::Notifier.should_receive(:add_notification).with(:terminal_notifier, {}, true).and_return false
-          Guard::Notifier.should_receive(:add_notification).with(:libnotify, {}, true).and_return false
-          Guard::Notifier.should_receive(:add_notification).with(:notifysend, {}, true).and_return false
-          Guard::Notifier.should_receive(:add_notification).with(:notifu, {}, true).and_return false
-          Guard::Notifier.should_receive(:add_notification).with(:emacs, {}, true).and_return false
-          Guard::Notifier.should_receive(:add_notification).with(:terminal_title, {}, true).and_return false
-          Guard::Notifier.should_receive(:add_notification).with(:tmux, {}, true).and_return false
-          Guard::Notifier.should_receive(:add_notification).with(:file, {}, true).and_return false
+          Guard::Notifier.should_receive(:add_notifier).with(:gntp, :silent => true).and_return false
+          Guard::Notifier.should_receive(:add_notifier).with(:growl, :silent => true).and_return false
+          Guard::Notifier.should_receive(:add_notifier).with(:growl_notify, :silent => true).and_return false
+          Guard::Notifier.should_receive(:add_notifier).with(:terminal_notifier, :silent => true).and_return false
+          Guard::Notifier.should_receive(:add_notifier).with(:libnotify, :silent => true).and_return false
+          Guard::Notifier.should_receive(:add_notifier).with(:notifysend, :silent => true).and_return false
+          Guard::Notifier.should_receive(:add_notifier).with(:notifu, :silent => true).and_return false
+          Guard::Notifier.should_receive(:add_notifier).with(:emacs, :silent => true).and_return false
+          Guard::Notifier.should_receive(:add_notifier).with(:terminal_title, :silent => true).and_return false
+          Guard::Notifier.should_receive(:add_notifier).with(:tmux, :silent => true).and_return false
+          Guard::Notifier.should_receive(:add_notifier).with(:file, :silent => true).and_return false
+
           Guard::Notifier.turn_on
         end
 
         it 'adds only the first notification per group' do
-          Guard::Notifier.should_receive(:add_notification).with(:gntp, {}, true).and_return false
-          Guard::Notifier.should_receive(:add_notification).with(:growl, {}, true).and_return false
-          Guard::Notifier.should_receive(:add_notification).with(:growl_notify, {}, true).and_return true
-          Guard::Notifier.should_not_receive(:add_notification).with(:terminal_notifier, {}, true)
-          Guard::Notifier.should_not_receive(:add_notification).with(:libnotify, {}, true)
-          Guard::Notifier.should_not_receive(:add_notification).with(:notifysend, {}, true)
-          Guard::Notifier.should_not_receive(:add_notification).with(:notifu, {}, true)
-          Guard::Notifier.should_receive(:add_notification).with(:emacs, {}, true)
-          Guard::Notifier.should_receive(:add_notification).with(:terminal_title, {}, true)
-          Guard::Notifier.should_receive(:add_notification).with(:tmux, {}, true)
-          Guard::Notifier.should_receive(:add_notification).with(:file, {}, true)
+          Guard::Notifier.should_receive(:add_notifier).with(:gntp, :silent => true).and_return false
+          Guard::Notifier.should_receive(:add_notifier).with(:growl, :silent => true).and_return false
+          Guard::Notifier.should_receive(:add_notifier).with(:growl_notify, :silent => true).and_return true
+          Guard::Notifier.should_not_receive(:add_notifier).with(:terminal_notifier, :silent => true)
+          Guard::Notifier.should_not_receive(:add_notifier).with(:libnotify, :silent => true)
+          Guard::Notifier.should_not_receive(:add_notifier).with(:notifysend, :silent => true)
+          Guard::Notifier.should_not_receive(:add_notifier).with(:notifu, :silent => true)
+          Guard::Notifier.should_receive(:add_notifier).with(:emacs, :silent => true)
+          Guard::Notifier.should_receive(:add_notifier).with(:terminal_title, :silent => true)
+          Guard::Notifier.should_receive(:add_notifier).with(:tmux, :silent => true)
+          Guard::Notifier.should_receive(:add_notifier).with(:file, :silent => true)
+
           Guard::Notifier.turn_on
         end
 
         it 'does enable the notifications when a library is available' do
-          Guard::Notifier.should_receive(:add_notification) do
-            Guard::Notifier.notifications = [{ :name => :gntp, :options => {} }]
+          Guard::Notifier.should_receive(:add_notifier) do
+            Guard::Notifier.notifiers = [gntp]
             true
           end.any_number_of_times
           Guard::Notifier.turn_on
@@ -75,16 +84,17 @@ describe Guard::Notifier do
         end
 
         it 'does turn on the notification module for libraries that are available' do
-          ::Guard::Notifier::GNTP.should_receive(:turn_on)
-          Guard::Notifier.should_receive(:add_notification) do
-            Guard::Notifier.notifications = [{ :name => :gntp, :options => {} }]
+          Guard::Notifier.should_receive(:add_notifier) do
+            Guard::Notifier.notifiers = [{ :name => :tmux, :options => {} }]
             true
           end.any_number_of_times
+          Guard::Notifier::Tmux.should_receive(:turn_on)
+
           Guard::Notifier.turn_on
         end
 
         it 'does not enable the notifications when no library is available' do
-          Guard::Notifier.should_receive(:add_notification).any_number_of_times.and_return false
+          Guard::Notifier.should_receive(:add_notifier).any_number_of_times.and_return false
           Guard::Notifier.turn_on
           Guard::Notifier.should_not be_enabled
         end
@@ -115,11 +125,12 @@ describe Guard::Notifier do
 
     context 'when turned on with available notifications' do
       before do
-        Guard::Notifier.notifications = [{ :name => :gntp, :options => {} }]
+        Guard::Notifier.notifiers = [{ :name => :tmux, :options => {} }]
       end
 
-      it 'turns off each notification' do
-        ::Guard::Notifier::GNTP.should_receive(:turn_off)
+      it 'turns off each notifier' do
+        Guard::Notifier::Tmux.should_receive(:turn_off)
+
         Guard::Notifier.turn_off
       end
     end
@@ -155,23 +166,25 @@ describe Guard::Notifier do
     end
   end
 
-  describe '.add_notification' do
+  describe '.add_notifier' do
     before do
-      Guard::Notifier.notifications = []
+      Guard::Notifier.clear_notifiers
     end
 
     context 'for an unknown notification library' do
       it 'does not add the library' do
-        Guard::Notifier.add_notification(:unknown)
-        Guard::Notifier.notifications.should be_empty
+        Guard::Notifier.add_notifier(:unknown)
+
+        Guard::Notifier.notifiers.should be_empty
       end
     end
 
-    context 'for an notification library with the name :off' do
+    context 'for a notification library with the name :off' do
       it 'disables the notifier' do
         ENV['GUARD_NOTIFY'] = 'true'
         Guard::Notifier.should be_enabled
-        Guard::Notifier.add_notification(:off)
+        Guard::Notifier.add_notifier(:off)
+
         Guard::Notifier.should_not be_enabled
       end
     end
@@ -179,81 +192,54 @@ describe Guard::Notifier do
     context 'for a supported notification library' do
       context 'that is available' do
         it 'adds the notifier to the notifications' do
-          Guard::Notifier::GNTP.should_receive(:available?).and_return true
-          Guard::Notifier.add_notification(:gntp, { :param => 1 })
-          Guard::Notifier.notifications.should include({ :name => :gntp, :options => { :param => 1 } })
+          Guard::Notifier::GNTP.should_receive(:available?).with(:param => 1).and_return(true)
+
+          Guard::Notifier.add_notifier(:gntp, :param => 1)
+
+          Guard::Notifier.notifiers.should eq [{ :name => :gntp, :options => { :param => 1 } }]
         end
       end
 
       context 'that is not available' do
         it 'does not add the notifier to the notifications' do
-          Guard::Notifier::GNTP.should_receive(:available?).and_return false
-          Guard::Notifier.add_notification(:gntp, { :param => 1 })
-          Guard::Notifier.notifications.should_not include({ :name => :gntp, :options => { :param => 1 } })
+          Guard::Notifier::GNTP.should_receive(:available?).with(:param => 1).and_return(false)
+          Guard::Notifier.add_notifier(:gntp, :param => 1)
+
+          Guard::Notifier.notifiers.should be_empty
         end
       end
     end
   end
 
   describe '.notify' do
+    before { Guard::Notifier.notifiers = [gntp, growl] }
+
     context 'when notifications are enabled' do
       before do
-        Guard::Notifier.notifications = [{ :name => :gntp, :options => {} }]
         Guard::Notifier.stub(:enabled?).and_return true
-      end
 
-      it 'uses the :success image when no image is defined' do
-        Guard::Notifier::GNTP.should_receive(:notify).with('success', 'Hi', 'Hi to everyone', /success.png/, {})
-        ::Guard::Notifier.notify('Hi to everyone', :title => 'Hi')
-      end
-
-      it 'uses "Guard" as title when no title is defined' do
-        Guard::Notifier::GNTP.should_receive(:notify).with('success', 'Guard', 'Hi to everyone', /success.png/, {})
-        ::Guard::Notifier.notify('Hi to everyone')
-      end
-
-      it 'sets the "failed" type for a :failed image' do
-        Guard::Notifier::GNTP.should_receive(:notify).with('failed', 'Guard', 'Hi to everyone', /failed.png/, {})
-        ::Guard::Notifier.notify('Hi to everyone', :image => :failed)
-      end
-
-      it 'sets the "pending" type for a :pending image' do
-        Guard::Notifier::GNTP.should_receive(:notify).with('pending', 'Guard', 'Hi to everyone', /pending.png/, {})
-        ::Guard::Notifier.notify('Hi to everyone', :image => :pending)
-      end
-
-      it 'sets the "success" type for a :success image' do
-        Guard::Notifier::GNTP.should_receive(:notify).with('success', 'Guard', 'Hi to everyone', /success.png/, {})
-        ::Guard::Notifier.notify('Hi to everyone', :image => :success)
-      end
-
-      it 'sets the "notify" type for a custom image' do
-        Guard::Notifier::GNTP.should_receive(:notify).with('notify', 'Guard', 'Hi to everyone', '/path/to/image.png', {})
-        ::Guard::Notifier.notify('Hi to everyone', :image => '/path/to/image.png')
-      end
-
-      it 'passes custom options to the notifier' do
-        Guard::Notifier::GNTP.should_receive(:notify).with('success', 'Guard', 'Hi to everyone', /success.png/, { :param => 'test' })
-        ::Guard::Notifier.notify('Hi to everyone', :param => 'test')
+        Guard::Notifier::GNTP.should_receive(:new).with({}).and_return(gntp_object)
+        Guard::Notifier::Growl.should_receive(:new).with({}).and_return(growl_object)
       end
 
       it 'sends the notification to multiple notifier' do
-        Guard::Notifier.notifications = [{ :name => :gntp, :options => {} }, { :name => :growl, :options => {} }]
-        Guard::Notifier::GNTP.should_receive(:notify)
-        Guard::Notifier::Growl.should_receive(:notify)
-        ::Guard::Notifier.notify('Hi to everyone')
+        Guard::Notifier.notifiers = [gntp, growl]
+        gntp_object.should_receive(:notify).with('Hi to everyone', :foo => 'bar')
+        growl_object.should_receive(:notify).with('Hi to everyone', :foo => 'bar')
+
+        ::Guard::Notifier.notify('Hi to everyone', :foo => 'bar')
       end
     end
 
     context 'when notifications are disabled' do
       before do
-        Guard::Notifier.notifications = [{ :name => :gntp, :options => {} }, { :name => :growl, :options => {} }]
         Guard::Notifier.stub(:enabled?).and_return false
       end
 
       it 'does not send any notifications to a notifier' do
-        Guard::Notifier::GNTP.should_not_receive(:notify)
-        Guard::Notifier::Growl.should_not_receive(:notify)
+        gntp.should_not_receive(:notify)
+        growl.should_not_receive(:notify)
+
         ::Guard::Notifier.notify('Hi to everyone')
       end
     end

--- a/spec/guard/notifiers/base_spec.rb
+++ b/spec/guard/notifiers/base_spec.rb
@@ -1,0 +1,163 @@
+require 'spec_helper'
+
+describe Guard::Notifier::Base do
+  let(:gntp)  { mock('GNTP notifier', :name => 'gntp', :title => 'GNTP', :options => {}) }
+  let(:growl) { mock('Growl notifier', :name => 'growl', :title => 'Growl', :options => {}) }
+
+  class Guard::Notifier::FooBar < described_class
+    def self.supported_hosts
+      ['freebsd', 'solaris']
+    end
+  end
+
+  before { subject.stub(:require) }
+
+  describe '.name' do
+    it 'un-modulizes the class, replaces "xY" with "x_Y" and downcase' do
+      Guard::Notifier::FooBar.name.should eq 'foo_bar'
+    end
+  end
+
+  describe '#name' do
+    it 'delegates to the class' do
+      Guard::Notifier::FooBar.new.name.should eq Guard::Notifier::FooBar.name
+    end
+  end
+
+  describe '.title' do
+    it 'un-modulize the class' do
+      Guard::Notifier::FooBar.title.should eq 'FooBar'
+    end
+  end
+
+  describe '#title' do
+    it 'delegates to the class' do
+      Guard::Notifier::FooBar.new.title.should eq Guard::Notifier::FooBar.title
+    end
+  end
+
+  describe '.normalize_standard_options!' do
+    context 'no opts given' do
+      let(:opts) { {} }
+
+      it 'returns the Guard title image when no :title is defined' do
+        described_class.new.normalize_standard_options!(opts)
+
+        opts[:title].should eq 'Guard'
+      end
+
+      it 'returns the :success type when no :type is defined' do
+        described_class.new.normalize_standard_options!(opts)
+
+        opts[:type].should eq :success
+      end
+
+      it 'returns the success.png image when no image is defined' do
+        described_class.new.normalize_standard_options!(opts)
+
+        opts[:image].should =~ /success.png/
+      end
+    end
+
+    context ':title given' do
+      let(:opts) { { :title => 'Hi' } }
+
+      it 'returns the passed :title' do
+        described_class.new.normalize_standard_options!(opts)
+
+        opts[:title].should eq 'Hi'
+      end
+    end
+
+    context ':type given' do
+      let(:opts) { { :type => :foo } }
+
+      it 'returns the passed :type' do
+        described_class.new.normalize_standard_options!(opts)
+
+        opts[:type].should eq :foo
+      end
+    end
+
+    context ':image => :failed given' do
+      let(:opts) { { :image => :failed } }
+
+      it 'sets the "failed" type for a :failed image' do
+        described_class.new.normalize_standard_options!(opts)
+
+        opts[:image].should =~ /failed.png/
+      end
+    end
+
+    context ':image => :pending given' do
+      let(:opts) { { :image => :pending } }
+
+      it 'sets the "pending" type for a :pending image' do
+        described_class.new.normalize_standard_options!(opts)
+
+        opts[:image].should =~ /pending.png/
+      end
+    end
+
+    context ':image => :success given' do
+      let(:opts) { { :image => :success } }
+
+      it 'sets the "success" type for a :success image' do
+        described_class.new.normalize_standard_options!(opts)
+
+        opts[:image].should =~ /success.png/
+      end
+    end
+
+    context ':image => "foo.png" given' do
+      let(:opts) { { :image => 'foo.png' } }
+
+      it 'sets the "success" type for a :success image' do
+        described_class.new.normalize_standard_options!(opts)
+
+        opts[:image].should eq 'foo.png'
+      end
+    end
+  end
+
+  describe '.available?' do
+    context 'without the silent option' do
+      it 'shows an error message when not available on the host OS' do
+        ::Guard::UI.should_receive(:error).with 'The :foo_bar notifier runs only on FreeBSD, Solaris.'
+        RbConfig::CONFIG.should_receive(:[]).with('host_os').and_return 'mswin'
+
+        Guard::Notifier::FooBar.available?
+      end
+    end
+  end
+
+  describe '.require_gem_safely' do
+    context 'library loads normally' do
+      it 'returns true' do
+        Guard::Notifier::FooBar.should_receive(:require).with('foo_bar')
+
+        Guard::Notifier::FooBar.require_gem_safely.should be_true
+      end
+    end
+
+    context 'library fails to load' do
+      it 'shows an error message when the gem cannot be loaded' do
+        ::Guard::UI.should_receive(:error).with "Please add \"gem 'foo_bar'\" to your Gemfile and run Guard with \"bundle exec\"."
+        Guard::Notifier::FooBar.should_receive(:require).with('foo_bar').and_raise LoadError
+
+        Guard::Notifier::FooBar.require_gem_safely.should be_false
+      end
+
+      context 'with the silent option' do
+        it 'does not show an error message when the gem cannot be loaded' do
+          ::Guard::UI.should_not_receive(:error).with "Please add \"gem 'growl_notify'\" to your Gemfile and run Guard with \"bundle exec\"."
+          Guard::Notifier::FooBar.should_receive(:require).with('foo_bar').and_raise LoadError
+
+          Guard::Notifier::FooBar.require_gem_safely(:silent => true).should be_false
+        end
+      end
+    end
+
+  end
+
+end

--- a/spec/guard/notifiers/emacs_spec.rb
+++ b/spec/guard/notifiers/emacs_spec.rb
@@ -11,33 +11,29 @@ describe Guard::Notifier::Emacs do
           command.should include(%{(set-face-attribute 'mode-line nil :background "ForestGreen" :foreground "White")})
         end
 
-        notifier.notify('success', 'any title', 'any message', 'any image', {})
+        notifier.notify('any message')
       end
     end
 
     context 'when a color option is specified for "success" notifications' do
-      let(:options) { { :success => 'Orange' } }
-
       it 'should set modeline color to the specified color using emacsclient' do
         notifier.should_receive(:_run_cmd).with do |*command|
           command.should include("emacsclient")
           command.should include(%{(set-face-attribute 'mode-line nil :background "Orange" :foreground "White")})
         end
 
-        notifier.notify('success', 'any title', 'any message', 'any image', options)
+        notifier.notify('any message', :success => 'Orange')
       end
     end
 
     context 'when a color option is specified for "pending" notifications' do
-      let(:options) { {:pending => 'Yellow'} }
-
       it 'should set modeline color to the specified color using emacsclient' do
         notifier.should_receive(:_run_cmd).with do |*command|
           command.should include("emacsclient")
           command.should include(%{(set-face-attribute 'mode-line nil :background "Yellow" :foreground "White")})
         end
 
-        notifier.notify('pending', 'any title', 'any message', 'any image', options)
+        notifier.notify('any message', :type => :pending, :pending => 'Yellow')
       end
     end
   end

--- a/spec/guard/notifiers/file_notifier_spec.rb
+++ b/spec/guard/notifiers/file_notifier_spec.rb
@@ -17,13 +17,13 @@ describe Guard::Notifier::FileNotifier do
     it 'writes to a file on success' do
       File.should_receive(:write).with('tmp/guard_result', "success\nany title\nany message\n")
 
-      notifier.notify('success', 'any title', 'any message', 'any image', { :path => 'tmp/guard_result' })
+      notifier.notify('any message', :title => 'any title', :path => 'tmp/guard_result')
     end
 
     it 'also writes to a file on failure' do
       File.should_receive(:write).with('tmp/guard_result', "failed\nany title\nany message\n")
 
-      notifier.notify('failed', 'any title', 'any message', 'any image', { :path => 'tmp/guard_result' })
+      notifier.notify('any message',:type => :failed, :title => 'any title', :path => 'tmp/guard_result')
     end
 
     # We don't have a way to return false in .available? when no path is
@@ -32,7 +32,7 @@ describe Guard::Notifier::FileNotifier do
       File.should_not_receive(:write)
       ::Guard::UI.should_receive(:error).with ":file notifier requires a :path option"
 
-      notifier.notify('success', 'any title', 'any message', 'any image', {})
+      notifier.notify('any message')
     end
   end
 

--- a/spec/guard/notifiers/growl_notify_spec.rb
+++ b/spec/guard/notifiers/growl_notify_spec.rb
@@ -1,50 +1,18 @@
 require 'spec_helper'
 
 describe Guard::Notifier::GrowlNotify do
-
-  let(:fake_growl_notify) do
-    Class.new do
-      def self.application_name; end
-      def self.send_notification(options) end
-    end
-  end
+  let(:notifier) { described_class.new }
 
   before do
-    subject.stub(:require)
-    stub_const 'GrowlNotify', fake_growl_notify
+    described_class.stub(:require_gem_safely).and_return(true)
+    stub_const 'GrowlNotify', stub
+  end
+
+  describe '.supported_hosts' do
+    it { described_class.supported_hosts.should eq %w[darwin] }
   end
 
   describe '.available?' do
-    context 'without the silent option' do
-      it 'shows an error message when not available on the host OS' do
-        ::Guard::UI.should_receive(:error).with 'The :growl_notify notifier runs only on Mac OS X.'
-        RbConfig::CONFIG.should_receive(:[]).with('host_os').and_return 'mswin'
-        subject.available?
-      end
-
-      it 'shows an error message when the gem cannot be loaded' do
-        RbConfig::CONFIG.should_receive(:[]).with('host_os').and_return 'darwin'
-        ::Guard::UI.should_receive(:error).with "Please add \"gem 'growl_notify'\" to your Gemfile and run Guard with \"bundle exec\"."
-        subject.should_receive(:require).with('growl_notify').and_raise LoadError
-        subject.available?
-      end
-    end
-
-    context 'with the silent option' do
-      it 'does not show an error message when not available on the host OS' do
-        ::Guard::UI.should_not_receive(:error).with 'The :growl_notify notifier runs only on Mac OS X.'
-        RbConfig::CONFIG.should_receive(:[]).with('host_os').and_return 'mswin'
-        subject.available?(true)
-      end
-
-      it 'does not show an error message when the gem cannot be loaded' do
-        RbConfig::CONFIG.should_receive(:[]).with('host_os').and_return 'darwin'
-        ::Guard::UI.should_not_receive(:error).with "Please add \"gem 'growl_notify'\" to your Gemfile and run Guard with \"bundle exec\"."
-        subject.should_receive(:require).with('growl_notify').and_raise LoadError
-        subject.available?(true)
-      end
-    end
-
     context 'when the application name is not Guard' do
       let(:config) { mock('config') }
 
@@ -55,7 +23,8 @@ describe Guard::Notifier::GrowlNotify do
         config.should_receive(:notifications=).with ['success', 'pending', 'failed', 'notify']
         config.should_receive(:default_notifications=).with 'notify'
         config.should_receive(:application_name=).with 'Guard'
-        subject.available?
+
+        described_class.should be_available
       end
     end
 
@@ -64,67 +33,45 @@ describe Guard::Notifier::GrowlNotify do
         RbConfig::CONFIG.should_receive(:[]).with('host_os').and_return 'darwin'
         ::GrowlNotify.should_receive(:application_name).and_return 'Guard'
         ::GrowlNotify.should_not_receive(:config)
-        subject.available?
+
+        described_class.should be_available
       end
     end
-
   end
 
-  describe '.nofify' do
-    it 'requires the library again' do
-      subject.should_receive(:require).with('growl_notify').and_return true
-      subject.notify('success', 'Welcome', 'Welcome to Guard', '/tmp/welcome.png', {})
-    end
-
+  describe '#notify' do
     context 'without additional options' do
       it 'shows the notification with the default options' do
-        ::GrowlNotify.should_receive(:send_notification).with({
-            :sticky           => false,
-            :priority         => 0,
-            :application_name => 'Guard',
-            :with_name        => 'success',
-            :title            => 'Welcome',
-            :description      => 'Welcome to Guard',
-            :icon             => '/tmp/welcome.png'
-        })
-        subject.notify('success', 'Welcome', 'Welcome to Guard', '/tmp/welcome.png', {})
+        ::GrowlNotify.should_receive(:send_notification).with(
+          :sticky           => false,
+          :priority         => 0,
+          :application_name => 'Guard',
+          :with_name        => 'success',
+          :title            => 'Welcome',
+          :description      => 'Welcome to Guard',
+          :icon             => '/tmp/welcome.png'
+        )
+
+        notifier.notify('Welcome to Guard', :type => :success, :title => 'Welcome', :image => '/tmp/welcome.png')
       end
     end
 
     context 'with additional options' do
       it 'can override the default options' do
-        ::GrowlNotify.should_receive(:send_notification).with({
-            :sticky           => true,
-            :priority         => -2,
-            :application_name => 'Guard',
-            :with_name        => 'pending',
-            :title            => 'Waiting',
-            :description      => 'Waiting for something',
-            :icon             => '/tmp/wait.png'
-        })
-        subject.notify('pending', 'Waiting', 'Waiting for something', '/tmp/wait.png', {
-            :sticky   => true,
-            :priority => -2
-        })
-      end
+        ::GrowlNotify.should_receive(:send_notification).with(
+          :sticky           => true,
+          :priority         => -2,
+          :application_name => 'Guard',
+          :with_name        => 'pending',
+          :title            => 'Waiting',
+          :description      => 'Waiting for something',
+          :icon             => '/tmp/wait.png'
+        )
 
-      it 'cannot override the core options' do
-        ::GrowlNotify.should_receive(:send_notification).with({
-            :sticky           => false,
-            :priority         => 0,
-            :application_name => 'Guard',
-            :with_name        => 'failed',
-            :title            => 'Failed',
-            :description      => 'Something failed',
-            :icon             => '/tmp/fail.png'
-        })
-        subject.notify('failed', 'Failed', 'Something failed', '/tmp/fail.png', {
-            :application_name => 'Guard CoffeeScript',
-            :with_name        => 'custom',
-            :title            => 'Duplicate title',
-            :description      => 'Duplicate description',
-            :icon             => 'Duplicate icon'
-        })
+        notifier.notify('Waiting for something', :type => :pending, :title => 'Waiting', :image => '/tmp/wait.png',
+          :sticky   => true,
+          :priority => -2
+        )
       end
     end
   end

--- a/spec/guard/notifiers/growl_spec.rb
+++ b/spec/guard/notifiers/growl_spec.rb
@@ -2,71 +2,26 @@ require 'spec_helper'
 
 describe Guard::Notifier::Growl do
   let(:notifier) { described_class.new }
-
-  let(:fake_growl) do
-    Class.new do
-      def self.notify(message, options) end
-      def self.installed?; end
-    end
-  end
+  let(:growl) { mock('Growl', :installed? => true) }
 
   before do
-    subject.stub(:require)
-    stub_const 'Growl', fake_growl
+    described_class.stub(:require_gem_safely).and_return(true)
+    stub_const 'Growl', growl
+  end
+
+  describe '.supported_hosts' do
+    it { described_class.supported_hosts.should eq %w[darwin] }
   end
 
   describe '.available?' do
-    context 'without the silent option' do
-      it 'shows an error message when not available on the host OS' do
-        ::Guard::UI.should_receive(:error).with 'The :growl notifier runs only on Mac OS X.'
-        RbConfig::CONFIG.should_receive(:[]).with('host_os').and_return 'linux'
-        subject.available?
-      end
+    it 'requires growl' do
+      described_class.should_receive(:require_gem_safely)
 
-      it 'shows an error message when the gem cannot be loaded' do
-        RbConfig::CONFIG.should_receive(:[]).with('host_os').and_return 'darwin'
-        ::Guard::UI.should_receive(:error).with "Please add \"gem 'growl'\" to your Gemfile and run Guard with \"bundle exec\"."
-        subject.should_receive(:require).with('growl').and_raise LoadError
-        subject.available?
-      end
-
-      it 'shows an error message when the growlnotify executable cannot be found' do
-        RbConfig::CONFIG.should_receive(:[]).with('host_os').and_return 'darwin'
-        ::Guard::UI.should_receive(:error).with "Please install the 'growlnotify' executable."
-        ::Growl.should_receive(:installed?).and_return false
-        subject.available?
-      end
-    end
-
-    context 'with the silent option' do
-      it 'does not show an error message when not available on the host OS' do
-        ::Guard::UI.should_not_receive(:error).with 'The :growl notifier runs only on Mac OS X.'
-        RbConfig::CONFIG.should_receive(:[]).with('host_os').and_return 'linux'
-        subject.available?(true)
-      end
-
-      it 'does not show an error message when the gem cannot be loaded' do
-        RbConfig::CONFIG.should_receive(:[]).with('host_os').and_return 'darwin'
-        ::Guard::UI.should_not_receive(:error).with "Please add \"gem 'growl'\" to your Gemfile and run Guard with \"bundle exec\"."
-        subject.should_receive(:require).with('growl').and_raise LoadError
-        subject.available?(true)
-      end
-
-      it 'does not show an error message when the growlnotify executable cannot be found' do
-        RbConfig::CONFIG.should_receive(:[]).with('host_os').and_return 'darwin'
-        ::Guard::UI.should_not_receive(:error).with "Please install the 'growlnotify' library."
-        ::Growl.should_receive(:installed?).and_return false
-        subject.available?(true)
-      end
+      described_class.should be_available
     end
   end
 
-  describe '.nofify' do
-    it 'requires the library again' do
-      subject.should_receive(:require).with('growl').and_return true
-      subject.notify('success', 'Welcome', 'Welcome to Guard', '/tmp/welcome.png', {})
-    end
-
+  describe '#notify' do
     context 'without additional options' do
       it 'shows the notification with the default options' do
         ::Growl.should_receive(:notify).with('Welcome to Guard',
@@ -77,7 +32,7 @@ describe Guard::Notifier::Growl do
           :image    => '/tmp/welcome.png'
         )
 
-        notifier.notify('success', 'Welcome', 'Welcome to Guard', '/tmp/welcome.png')
+        notifier.notify('Welcome to Guard', :title => 'Welcome', :image => '/tmp/welcome.png')
       end
     end
 
@@ -91,25 +46,9 @@ describe Guard::Notifier::Growl do
           :image    => '/tmp/wait.png'
         )
 
-        notifier.notify('pending', 'Waiting', 'Waiting for something', '/tmp/wait.png',
+        notifier.notify('Waiting for something', :type => :pending, :title => 'Waiting', :image => '/tmp/wait.png',
           :sticky   => true,
           :priority => 2
-        )
-      end
-
-      it 'cannot override the core options' do
-        ::Growl.should_receive(:notify).with('Something failed',
-          :sticky   => false,
-          :priority => 0,
-          :name     => 'Guard',
-          :title    => 'Failed',
-          :image    => '/tmp/fail.png'
-        )
-
-        notifier.notify('failed', 'Failed', 'Something failed', '/tmp/fail.png',
-          :name  => 'custom',
-          :title => 'Duplicate title',
-          :image => 'Duplicate image'
         )
       end
     end

--- a/spec/guard/notifiers/libnotify_spec.rb
+++ b/spec/guard/notifiers/libnotify_spec.rb
@@ -4,48 +4,23 @@ describe Guard::Notifier::Libnotify do
   let(:notifier) { described_class.new }
 
   before do
-    subject.stub(:require)
+    described_class.stub(:require_gem_safely).and_return(true)
     stub_const 'Libnotify', stub
   end
 
+  describe '.supported_hosts' do
+    it { described_class.supported_hosts.should eq %w[linux freebsd openbsd sunos solaris] }
+  end
+
   describe '.available?' do
-    context 'without the silent option' do
-      it 'shows an error message when not available on the host OS' do
-        ::Guard::UI.should_receive(:error).with 'The :libnotify notifier runs only on Linux, FreeBSD, OpenBSD and Solaris.'
-        RbConfig::CONFIG.should_receive(:[]).with('host_os').and_return 'darwin'
-        subject.available?
-      end
+    it 'requires libnotify' do
+      described_class.should_receive(:require_gem_safely)
 
-      it 'shows an error message when the gem cannot be loaded' do
-        RbConfig::CONFIG.should_receive(:[]).with('host_os').and_return 'linux'
-        ::Guard::UI.should_receive(:error).with "Please add \"gem 'libnotify'\" to your Gemfile and run Guard with \"bundle exec\"."
-        subject.should_receive(:require).with('libnotify').and_raise LoadError
-        subject.available?
-      end
-    end
-
-    context 'with the silent option' do
-      it 'does not show an error message when not available on the host OS' do
-        ::Guard::UI.should_not_receive(:error).with 'The :libnotify notifier runs only on Linux, FreeBSD, OpenBSD and Solaris.'
-        RbConfig::CONFIG.should_receive(:[]).with('host_os').and_return 'darwin'
-        subject.available?(true)
-      end
-
-      it 'does not show an error message when the gem cannot be loaded' do
-        RbConfig::CONFIG.should_receive(:[]).with('host_os').and_return 'linux'
-        ::Guard::UI.should_not_receive(:error).with "Please add \"gem 'libnotify'\" to your Gemfile and run Guard with \"bundle exec\"."
-        subject.should_receive(:require).with('libnotify').and_raise LoadError
-        subject.available?(true)
-      end
+      described_class.should be_available
     end
   end
 
-  describe '.notify' do
-    it 'requires the library again' do
-      subject.should_receive(:require).with('libnotify').and_return true
-      subject.notify('success', 'Welcome', 'Welcome to Guard', '/tmp/welcome.png', {})
-    end
-
+  describe '#notify' do
     context 'without additional options' do
       it 'shows the notification with the default options' do
         ::Libnotify.should_receive(:show).with(
@@ -58,7 +33,7 @@ describe Guard::Notifier::Libnotify do
           :icon_path => '/tmp/welcome.png'
         )
 
-        notifier.notify('success', 'Welcome', 'Welcome to Guard', '/tmp/welcome.png')
+        notifier.notify('Welcome to Guard', :title => 'Welcome', :image => '/tmp/welcome.png')
       end
     end
 
@@ -74,29 +49,11 @@ describe Guard::Notifier::Libnotify do
           :icon_path => '/tmp/wait.png'
         )
 
-        notifier.notify('pending', 'Waiting', 'Waiting for something', '/tmp/wait.png',
+        notifier.notify('Waiting for something', :type => :pending, :title => 'Waiting', :image => '/tmp/wait.png',
           :transient => true,
           :append    => false,
           :timeout   => 5,
           :urgency   => :critical
-        )
-      end
-
-      it 'cannot override the core options' do
-        ::Libnotify.should_receive(:show).with(
-          :transient => false,
-          :append    => true,
-          :timeout   => 3,
-          :urgency   => :normal,
-          :summary   => 'Failed',
-          :body      => 'Something failed',
-          :icon_path => '/tmp/fail.png'
-        )
-
-        notifier.notify('failed', 'Failed', 'Something failed', '/tmp/fail.png',
-          :summary   => 'Duplicate title',
-          :body      => 'Duplicate body',
-          :icon_path => 'Duplicate icon'
         )
       end
     end

--- a/spec/guard/notifiers/terminal_title_spec.rb
+++ b/spec/guard/notifiers/terminal_title_spec.rb
@@ -1,29 +1,23 @@
 require 'spec_helper'
 
 describe Guard::Notifier::TerminalTitle do
+  let(:notifier) { described_class.new }
 
   before do
     subject.stub!(:puts)
   end
 
   describe '.available?' do
-    context 'without the silent option' do
-      it 'returns true' do
-        subject.available?.should be_true
-      end
-    end
-
-    context 'with the silent option' do
-      it 'returns true' do
-        subject.available?.should be_true
-      end
+    it 'returns true' do
+      described_class.should be_available
     end
   end
 
-  describe '.notify' do
+  describe '#notify' do
     it 'set title + first line of message to terminal title' do
-      subject.should_receive(:puts).with("\e]2;[any title] first line\a")
-      subject.notify('success', 'any title', "first line\nsecond line\nthird", 'any image', {})
+      notifier.should_receive(:puts).with("\e]2;[any title] first line\a")
+
+      notifier.notify("first line\nsecond line\nthird", :title => 'any title')
     end
   end
 

--- a/spec/guard/notifiers/tmux_spec.rb
+++ b/spec/guard/notifiers/tmux_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe Guard::Notifier::Tmux do
+  let(:notifier) { described_class.new }
 
   describe '.available?' do
     context 'when the TMUX environment variable is set' do
@@ -8,8 +9,8 @@ describe Guard::Notifier::Tmux do
         ENV['TMUX'] = 'something'
       end
 
-      it 'should return true' do
-        subject.available?.should be_true
+      it 'returns true' do
+        described_class.should be_available
       end
     end
 
@@ -21,138 +22,149 @@ describe Guard::Notifier::Tmux do
       context 'without the silent option' do
         it 'shows an error message when the TMUX environment variable is not set' do
           ::Guard::UI.should_receive(:error).with 'The :tmux notifier runs only on when Guard is executed inside of a tmux session.'
-          subject.available?
+
+          described_class.should_not be_available
         end
       end
 
       context 'with the silent option' do
-        it 'should return false' do
-          subject.available?(true).should be_false
+        it 'returns false' do
+          described_class.should_not be_available(:silent => true)
         end
       end
     end
   end
 
-  describe '.notify' do
+  describe '#notify' do
     it 'should set the tmux status bar color to green on success' do
-      subject.should_receive(:system).with 'tmux set status-left-bg green'
+      notifier.should_receive(:system).with 'tmux set status-left-bg green'
 
-      subject.notify('success', 'any title', 'any message', 'any image', {})
+      notifier.notify('any message', :type => :success)
     end
 
     it 'should set the tmux status bar color to black on success when black is passed in as an option' do
-      subject.should_receive(:system).with "tmux set status-left-bg black"
+      notifier.should_receive(:system).with "tmux set status-left-bg black"
 
-      subject.notify('success', 'any title', 'any message', 'any image', { :success => 'black' })
+      notifier.notify('any message', :type => :success, :success => 'black')
     end
 
     it 'should set the tmux status bar color to red on failure' do
-      subject.should_receive(:system).with 'tmux set status-left-bg red'
+      notifier.should_receive(:system).with 'tmux set status-left-bg red'
 
-      subject.notify('failed', 'any title', 'any message', 'any image', {})
+      notifier.notify('any message', :type => :failed)
     end
 
     it 'should set the tmux status bar color to yellow on pending' do
-      subject.should_receive(:system).with 'tmux set status-left-bg yellow'
+      notifier.should_receive(:system).with 'tmux set status-left-bg yellow'
 
-      subject.notify('pending', 'any title', 'any message', 'any image', {})
+      notifier.notify('any message', :type => :pending)
     end
 
     it 'should set the tmux status bar color to green on notify' do
-      subject.should_receive(:system).with 'tmux set status-left-bg green'
+      notifier.should_receive(:system).with 'tmux set status-left-bg green'
 
-      subject.notify('notify', 'any title', 'any message', 'any image', {})
+      notifier.notify('any message', :type => :notify)
     end
 
     it 'should set the right tmux status bar color on success when the right status bar is passed in as an option' do
-      subject.should_receive(:system).with 'tmux set status-right-bg green'
+      notifier.should_receive(:system).with 'tmux set status-right-bg green'
 
-      subject.notify('success', 'any title', 'any message', 'any image', { :color_location => 'status-right-bg' })
+      notifier.notify('any message', :color_location => 'status-right-bg')
     end
 
     it 'calls display_message if the display_message flag is set' do
-      subject.stub :system => true
-      subject.should_receive(:display_message).with('notify', 'any title', 'any message', { :display_message => true })
+      notifier.stub :system => true
+      notifier.should_receive(:display_message).with('notify', 'Guard', 'any message', :display_message => true)
 
-      subject.notify('notify', 'any title', 'any message', 'any image', { :display_message => true })
+      notifier.notify('any message', :type => :notify, :display_message => true)
     end
 
     it 'does not call display message if the display_message flag is not set' do
-      subject.stub :system => true
-      subject.should_receive(:display_message).never
+      notifier.stub :system => true
+      notifier.should_receive(:display_message).never
 
-      subject.notify('notify', 'any title', 'any message', 'any image', {})
+      notifier.notify('any message')
     end
   end
 
-  describe '.display_message' do
+  describe '#display_message' do
     before do
-      subject.stub :system => true
+      notifier.stub :system => true
     end
 
     it 'sets the display-time' do
-      subject.should_receive(:system).with('tmux set display-time 3000')
-      subject.display_message 'success', 'any title', 'any message', :timeout => 3
+      notifier.should_receive(:system).with('tmux set display-time 3000')
+
+      notifier.display_message 'success', 'any title', 'any message', :timeout => 3
     end
 
     it 'displays the message' do
-      subject.should_receive(:system).with('tmux display-message \'any title - any message\'').once
-      subject.display_message 'success', 'any title', 'any message'
+      notifier.should_receive(:system).with('tmux display-message \'any title - any message\'').once
+
+      notifier.display_message 'success', 'any title', 'any message'
     end
 
     it 'handles line-breaks' do
-      subject.should_receive(:system).with('tmux display-message \'any title - any message xx line two\'').once
-      subject.display_message 'success', 'any title', "any message\nline two", :line_separator => ' xx '
+      notifier.should_receive(:system).with('tmux display-message \'any title - any message xx line two\'').once
+
+      notifier.display_message 'success', 'any title', "any message\nline two", :line_separator => ' xx '
     end
 
     context 'with success message type options' do
       it 'formats the message' do
-        subject.should_receive(:system).with('tmux display-message \'[any title] => any message - line two\'').once
-        subject.display_message 'success', 'any title', "any message\nline two", :success_message_format => '[%s] => %s', :default_message_format => '(%s) -> %s'
+        notifier.should_receive(:system).with('tmux display-message \'[any title] => any message - line two\'').once
+
+        notifier.display_message 'success', 'any title', "any message\nline two", :success_message_format => '[%s] => %s', :default_message_format => '(%s) -> %s'
       end
 
       it 'sets the foreground color based on the type for success' do
-        subject.should_receive(:system).with('tmux set message-fg green')
-        subject.display_message 'success', 'any title', 'any message', { :success_message_color => 'green' }
+        notifier.should_receive(:system).with('tmux set message-fg green')
+
+        notifier.display_message 'success', 'any title', 'any message', { :success_message_color => 'green' }
       end
 
       it 'sets the background color' do
-        subject.should_receive(:system).with('tmux set message-bg blue')
-        subject.display_message 'success', 'any title', 'any message', { :success => :blue }
+        notifier.should_receive(:system).with('tmux set message-bg blue')
+
+        notifier.display_message 'success', 'any title', 'any message', { :success => :blue }
       end
     end
 
     context 'with pending message type options' do
       it 'formats the message' do
-        subject.should_receive(:system).with('tmux display-message \'[any title] === any message - line two\'').once
-        subject.display_message 'pending', 'any title', "any message\nline two", :pending_message_format => '[%s] === %s', :default_message_format => '(%s) -> %s'
+        notifier.should_receive(:system).with('tmux display-message \'[any title] === any message - line two\'').once
+
+        notifier.display_message 'pending', 'any title', "any message\nline two", :pending_message_format => '[%s] === %s', :default_message_format => '(%s) -> %s'
       end
 
       it 'sets the foreground color' do
-        subject.should_receive(:system).with('tmux set message-fg blue')
-        subject.display_message 'pending', 'any title', 'any message', { :pending_message_color => 'blue' }
+        notifier.should_receive(:system).with('tmux set message-fg blue')
+
+        notifier.display_message 'pending', 'any title', 'any message', :pending_message_color => 'blue'
       end
 
       it 'sets the background color' do
-        subject.should_receive(:system).with('tmux set message-bg white')
-        subject.display_message 'pending', 'any title', 'any message', { :pending => :white }
+        notifier.should_receive(:system).with('tmux set message-bg white')
+
+        notifier.display_message 'pending', 'any title', 'any message', :pending => :white
       end
     end
 
     context 'with failed message type options' do
       it 'formats the message' do
-        subject.should_receive(:system).with('tmux display-message \'[any title] <=> any message - line two\'').once
-        subject.display_message 'failed', 'any title', "any message\nline two", :failed_message_format => '[%s] <=> %s', :default_message_format => '(%s) -> %s'
+        notifier.should_receive(:system).with('tmux display-message \'[any title] <=> any message - line two\'').once
+
+        notifier.display_message 'failed', 'any title', "any message\nline two", :failed_message_format => '[%s] <=> %s', :default_message_format => '(%s) -> %s'
       end
 
       it 'sets the foreground color' do
-        subject.should_receive(:system).with('tmux set message-fg red')
-        subject.display_message 'failed', 'any title', 'any message', { :failed_message_color => 'red' }
+        notifier.should_receive(:system).with('tmux set message-fg red')
+        notifier.display_message 'failed', 'any title', 'any message', :failed_message_color => 'red'
       end
 
       it 'sets the background color' do
-        subject.should_receive(:system).with('tmux set message-bg black')
-        subject.display_message 'failed', 'any title', 'any message', { :failed => :black }
+        notifier.should_receive(:system).with('tmux set message-bg black')
+        notifier.display_message 'failed', 'any title', 'any message', :failed => :black
       end
     end
 
@@ -160,105 +172,116 @@ describe Guard::Notifier::Tmux do
 
   describe '.turn_on' do
     before do
-      subject.stub(:`).and_return("option1 setting1\noption2 setting2\n")
-      subject.stub :system => true
+      notifier.stub(:`).and_return("option1 setting1\noption2 setting2\n")
+      notifier.stub :system => true
     end
 
     it 'quiets the tmux output' do
-      subject.should_receive(:system).with 'tmux set quiet on'
-      subject.turn_on
+      notifier.should_receive(:system).with 'tmux set quiet on'
+
+      notifier.turn_on
     end
 
     context 'when off' do
       before do
-        subject.turn_off
+        notifier.turn_off
       end
 
       it 'resets the options store' do
-        subject.should_receive(:reset_options_store)
-        subject.turn_on
+        notifier.should_receive(:_reset_options_store)
+
+        notifier.turn_on
       end
 
       it 'saves the current tmux options' do
-        subject.should_receive(:`).with('tmux show')
-        subject.turn_on
+        notifier.should_receive(:`).with('tmux show')
+
+        notifier.turn_on
       end
     end
 
     context 'when on' do
       before do
-        subject.turn_on
+        notifier.turn_on
       end
 
       it 'does not reset the options store' do
-        subject.should_not_receive(:reset_options_store)
-        subject.turn_on
+        notifier.should_not_receive(:_reset_options_store)
+
+        notifier.turn_on
       end
 
       it 'does not save the current tmux options' do
-        subject.should_not_receive(:`).with('tmux show')
-        subject.turn_on
+        notifier.should_not_receive(:`).with('tmux show')
+
+        notifier.turn_on
       end
     end
   end
 
   describe '.turn_off' do
     before do
-      subject.stub(:`).and_return("option1 setting1\noption2 setting2\n")
-      subject.stub :system => true
+      notifier.stub(:`).and_return("option1 setting1\noption2 setting2\n")
+      notifier.stub :system => true
     end
 
     context 'when on' do
       before do
-        subject.turn_on
+        notifier.turn_on
       end
 
       it 'restores the tmux options' do
-        subject.should_receive(:system).with('tmux set option2 setting2')
-        subject.should_receive(:system).with('tmux set -u status-left-bg')
-        subject.should_receive(:system).with('tmux set option1 setting1')
-        subject.should_receive(:system).with('tmux set -u status-right-bg')
-        subject.should_receive(:system).with('tmux set -u status-right-fg')
-        subject.should_receive(:system).with('tmux set -u status-left-fg')
-        subject.should_receive(:system).with('tmux set -u message-fg')
-        subject.should_receive(:system).with('tmux set -u message-bg')
-        subject.turn_off
+        notifier.should_receive(:system).with('tmux set option2 setting2')
+        notifier.should_receive(:system).with('tmux set -u status-left-bg')
+        notifier.should_receive(:system).with('tmux set option1 setting1')
+        notifier.should_receive(:system).with('tmux set -u status-right-bg')
+        notifier.should_receive(:system).with('tmux set -u status-right-fg')
+        notifier.should_receive(:system).with('tmux set -u status-left-fg')
+        notifier.should_receive(:system).with('tmux set -u message-fg')
+        notifier.should_receive(:system).with('tmux set -u message-bg')
+
+        notifier.turn_off
       end
 
       it 'resets the options store' do
-        subject.should_receive(:reset_options_store)
-        subject.turn_off
+        notifier.should_receive(:_reset_options_store)
+
+        notifier.turn_off
       end
 
       it 'unquiets the tmux output' do
-        subject.should_receive(:system).with 'tmux set quiet off'
-        subject.turn_off
+        notifier.should_receive(:system).with 'tmux set quiet off'
+
+        notifier.turn_off
       end
     end
 
     context 'when off' do
       before do
-        subject.turn_off
+        notifier.turn_off
       end
 
       it 'does not restore the tmux options' do
-        subject.should_not_receive(:system).with('tmux set -u status-left-bg')
-        subject.should_not_receive(:system).with('tmux set -u status-right-bg')
-        subject.should_not_receive(:system).with('tmux set -u status-right-fg')
-        subject.should_not_receive(:system).with('tmux set -u status-left-fg')
-        subject.should_not_receive(:system).with('tmux set -u message-fg')
-        subject.should_not_receive(:system).with('tmux set -u message-bg')
-        subject.turn_off
+        notifier.should_not_receive(:system).with('tmux set -u status-left-bg')
+        notifier.should_not_receive(:system).with('tmux set -u status-right-bg')
+        notifier.should_not_receive(:system).with('tmux set -u status-right-fg')
+        notifier.should_not_receive(:system).with('tmux set -u status-left-fg')
+        notifier.should_not_receive(:system).with('tmux set -u message-fg')
+        notifier.should_not_receive(:system).with('tmux set -u message-bg')
+
+        notifier.turn_off
       end
 
       it 'does not reset the options store' do
-        subject.should_not_receive(:reset_options_store)
-        subject.turn_off
+        notifier.should_not_receive(:_reset_options_store)
+
+        notifier.turn_off
       end
 
       it 'unquiets the tmux output' do
-        subject.should_receive(:system).with 'tmux set quiet off'
-        subject.turn_off
+        notifier.should_receive(:system).with 'tmux set quiet off'
+
+        notifier.turn_off
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,9 +36,8 @@ RSpec.configure do |config|
 
   config.before(:all) do
     ::Guard::Notifier.send(:_auto_detect_notification)
-
-    @guard_notify = ENV['GUARD_NOTIFY']
-    @guard_notifications = ::Guard::Notifier.notifications
+    @guard_notify ||= ENV['GUARD_NOTIFY']
+    @guard_notifiers ||= ::Guard::Notifier.notifiers
   end
 
   config.after(:each) do
@@ -50,7 +49,7 @@ RSpec.configure do |config|
 
   config.after(:all) do
     ENV['GUARD_NOTIFY'] = @guard_notify
-    ::Guard::Notifier.notifications = @guard_notifications
+    ::Guard::Notifier.notifiers = @guard_notifiers
   end
 
 end


### PR DESCRIPTION
Notifiers are now classes with a common interface
inherited from `Guard::Notifier::Base`:
- `#notify` (required)
- `.available?` (optional)
- `.supported_hosts` (optional)
- `.gem_name` (optional)

What do you think of this?

Also, I think after this refactoring it'd be very easy to extract the notifiers
to a separate gem. I couldn't find such gem (there's [notifier](http://rubygems.org/gems/notifier) but I don't really like its
approach...) so I thought we could create a new one and name it "Brief"!

What do you @guard/core-team think?
