### PR TITLE
Correctly memoize our knowledge of the existence of stty

### DIFF
--- a/lib/guard/interactor.rb
+++ b/lib/guard/interactor.rb
@@ -89,6 +89,7 @@ module Guard
       Pry.config.should_load_local_rc = false
       Pry.config.history.file         = File.expand_path(self.class.options[:history_file] || HISTORY_FILE)
 
+      @stty_exists = nil
       add_hooks
 
       replace_reset_command
@@ -270,7 +271,8 @@ module Guard
     # @return [Boolean] the status of stty
     #
     def stty_exists?
-      @stty_exists ||= system('hash', 'stty')
+      @stty_exists ||= system('hash', 'stty') ? true : false if @stty_exists.nil?
+      @stty_exists
     end
 
     # Stores the terminal settings so we can resore them


### PR DESCRIPTION
Three states are required for memoizing whether stty exists: yes, no & unknown. The prior implementation does not distinguish between the no & unknown states. On Wiindows, where stty is not likely to exist, this results in #stty_exists? rechecking every time for existence of stty.
