### PR TITLE
Code around apparent bug in Thread#alive?

### DIFF
--- a/lib/guard/interactor.rb
+++ b/lib/guard/interactor.rb
@@ -240,7 +240,7 @@ module Guard
 
       store_terminal_settings if stty_exists?
 
-      if !@thread || !@thread.alive?
+      if !@thread || !['sleep', 'run'].include?(@thread.status)
         ::Guard::UI.debug 'Start interactor'
 
         @thread = Thread.new do


### PR DESCRIPTION
The documentation for Thread#alive? states that it "Returns true if [the thread] is running or sleeping." In ruby 1.9.3p429 (2013-05-15) [i386-mingw32], it also returns true when the status is 'aborting'. Explicitly checking for states fixes this bug.
