### PR TITLE
Replace use of '/dev/null' with DEV_NULL throughout the gem

### DIFF
--- a/lib/guard/interactor.rb
+++ b/lib/guard/interactor.rb
@@ -120,7 +120,7 @@ module Guard
 
       if stty_exists?
         Pry.config.hooks.add_hook :after_eval, :restore_visibility do
-          system('stty echo 2>/dev/null')
+          system("stty echo 2>#{ DEV_NULL }")
         end
       end
     end

--- a/lib/guard/notifiers/tmux.rb
+++ b/lib/guard/notifiers/tmux.rb
@@ -164,7 +164,7 @@ module Guard
       private
 
       def system(args)
-        args += " >/dev/null 2>&1" if ENV['GUARD_ENV'] == 'test'
+        args += " >#{ DEV_NULL } 2>&1" if ENV['GUARD_ENV'] == 'test'
         super
       end
 

--- a/spec/guard/watcher_spec.rb
+++ b/spec/guard/watcher_spec.rb
@@ -78,7 +78,7 @@ describe Guard::Watcher do
             described_class.new('hash.rb',        lambda { Hash[:foo, 'bar'] }),
             described_class.new('array.rb',       lambda { ['foo', 'bar'] }),
             described_class.new('blank.rb',       lambda { '' }),
-            described_class.new(/^uptime\.rb/,    lambda { `uptime > /dev/null` })
+            described_class.new(/^uptime\.rb/,    lambda { `uptime > #{ DEV_NULL }` })
           ]
         end
 
@@ -115,7 +115,7 @@ describe Guard::Watcher do
             described_class.new('hash.rb',        lambda { Hash[:foo, 'bar'] }),
             described_class.new('array.rb',       lambda { ['foo', 'bar'] }),
             described_class.new('blank.rb',       lambda { '' }),
-            described_class.new(/^uptime\.rb/,    lambda { `uptime > /dev/null` })
+            described_class.new(/^uptime\.rb/,    lambda { `uptime > #{ DEV_NULL }` })
           ]
         end
 
@@ -156,7 +156,7 @@ describe Guard::Watcher do
              described_class.new('hash.rb',          lambda { |m| Hash[:foo, 'bar'] }),
              described_class.new(/array(.*)\.rb/,    lambda { |m| ['foo', 'bar'] }),
              described_class.new(/blank(.*)\.rb/,    lambda { |m| '' }),
-             described_class.new(/uptime(.*)\.rb/,   lambda { |m| `uptime > /dev/null` })
+             described_class.new(/uptime(.*)\.rb/,   lambda { |m| `uptime > #{ DEV_NULL }` })
            ]
          end
 
@@ -193,7 +193,7 @@ describe Guard::Watcher do
             described_class.new('hash.rb',          lambda { |m| Hash[:foo, 'bar', :file_name, m[0]] }),
             described_class.new(/array(.*)\.rb/,    lambda { |m| ['foo', 'bar', m[0]] }),
             described_class.new(/blank(.*)\.rb/,    lambda { |m| '' }),
-            described_class.new(/uptime(.*)\.rb/,   lambda { |m| `uptime > /dev/null` })
+            described_class.new(/uptime(.*)\.rb/,   lambda { |m| `uptime > #{ DEV_NULL }` })
           ]
         end
 


### PR DESCRIPTION
DEV_NULL is a constant that is evaluated at load time. On Windows, this constant is set to 'NUL' on linux, it is set to '/dev/null'
