### PR TITLE
Accommodate differences in Thread class under MRI 1.9.3, MRI 2.0.0 and jruby

### DIFF
--- a/lib/guard/interactor.rb
+++ b/lib/guard/interactor.rb
@@ -126,7 +126,7 @@ module Guard
 
       _store_terminal_settings if _stty_exists?
 
-      if !@thread || !['sleep', 'run'].include?(@thread.status)
+      unless @thread
         ::Guard::UI.debug 'Start interactor'
 
         @thread = Thread.new do
@@ -145,6 +145,7 @@ module Guard
         ::Guard::UI.reset_line
         ::Guard::UI.debug 'Stop interactor'
         @thread.kill
+        @thread = nil
       end
 
       _restore_terminal_settings if _stty_exists?


### PR DESCRIPTION
On a newly killed thread, Thread#alive? behaves differently under MRI 2.0.0 than under MRI 1.9.3, and jruby and Thread#status behaves differently under jruby than under MRI 1.9.3, and MRI 2.0.0.

  t=Thread.new{}.kill; puts "#{t.alive?}--#{t.status}"

  On MRI 1.9.3 => true--aborting
  On MRI 2.0.0 => true--run
  On jruby        => false--aborting
