### PR TITLE
Allow multiple values for the tmux notifier color_location option

### DIFF
--- a/lib/guard/notifiers/tmux.rb
+++ b/lib/guard/notifiers/tmux.rb
@@ -83,7 +83,7 @@ module Guard
       # @option opts [String] image the path to the notification image
       # @option opts [Boolean] change_color whether to show a color
       #   notification
-      # @option opts [String] color_location the location where to draw the
+      # @option opts [String,Array] color_location the location where to draw the
       #   color notification
       # @option opts [Boolean] display_message whether to display a message
       #   or not
@@ -93,10 +93,12 @@ module Guard
         opts.delete(:image)
 
         if opts.fetch(:change_color, DEFAULTS[:change_color])
-          color_location = opts.fetch(:color_location, DEFAULTS[:color_location])
+          color_locations = Array(opts.fetch(:color_location, DEFAULTS[:color_location]))
           color = tmux_color(opts[:type], opts)
 
-          _run_client "set #{ color_location } #{ color }"
+          color_locations.each do |color_location|
+            _run_client "set #{ color_location } #{ color }"
+          end
         end
 
         if opts.fetch(:display_message, DEFAULTS[:display_message])

--- a/spec/guard/notifiers/tmux_spec.rb
+++ b/spec/guard/notifiers/tmux_spec.rb
@@ -109,6 +109,13 @@ describe Guard::Notifier::Tmux do
 
       notifier.notify('any message')
     end
+
+    it 'should set the color on multiple tmux settings when color_location is passed with an array' do
+      expect(notifier).to receive(:system).with 'tmux set status-left-bg green'
+      expect(notifier).to receive(:system).with 'tmux set pane-border-fg green'
+
+      notifier.notify('any message', color_location: %w[status-left-bg pane-border-fg])
+    end
   end
 
   describe '#display_message' do


### PR DESCRIPTION
This allows you to set the color of multiple tmux options with the tmux notifier.

For example, I have this in my `~/.guard.rb`:

``` ruby
notification(:tmux, {
  :display_message => false,
  :success => 'colour150',
  :failure => 'colour174',
  :pending => 'colour179',
  :color_location => %w[status-left-bg pane-active-border-fg pane-border-fg],
}) if ENV['TMUX']
```

I'm happy to update https://github.com/guard/guard/wiki/System-notifications if this gets merged.
