### PR TITLE
Fix options changed after pass it to any notifiers

### DIFF
--- a/lib/guard/notifier.rb
+++ b/lib/guard/notifier.rb
@@ -174,7 +174,7 @@ module Guard
         notifier = _get_notifier_module(notifier[:name]).new(notifier[:options])
 
         begin
-          notifier.notify(message, opts)
+          notifier.notify(message, opts.dup)
         rescue Exception => e
           ::Guard::UI.error "Error sending notification with #{ notifier.name }: #{ e.message }"
           ::Guard::UI.debug e.backtrace.join("\n")


### PR DESCRIPTION
Hi All,

  I got some errors when running tests with guard and guard-gotest, below are those notifiers I am using.

```
22:38:11 - INFO - Guard is using Libnotify to send notifications.
22:38:11 - INFO - Guard is using Emacs to send notifications.
22:38:11 - INFO - Guard is using TerminalTitle to send notifications.
22:38:11 - INFO - Guard::Gotest is running
```

My error is Libnotify reported tests failed when got some errors, but emacs got success notification.

When I look into guard, and try to prints the `opts` at `lib/guard/notifier.rb#177` (v2.2.1) and found the opts was changed after finish every notification:

When send the first notification, the opts is `{:title=>"Gotest results", :type=>:failed, :priority=>2}` 
After finish the first notification, the opts changed to `{:priority=>2}`, (missed the failed type)
After finish the emacs notification, the value became `{:priority=>2, :title=>"Guard", :type=>:success, :image=>"/home/jinzhu/.gem/ruby/2.0.0/gems/guard-2.2.1/images/success.png"}` (Got some unexpected values)

After doing some research, I found every notifier's notify method inherit Guard::Notifier::Base#notify, but the code of Guard::Notifier::Base#notify looks strange for me:

```
      def notify(message, opts = {})
        options.delete(:silent)
        ***opts.replace(options.merge(opts))***
        normalize_standard_options!(opts)
      end
```

It will update the original opts passed to it. I think it should only update the opts for this notifier but not global. So maybe pass a cloned options to each notifier should be a better idea.

Here is a simple code base to explain what's the error, hope it make sense:

```
def notify opts 
  opts.replace opts.merge(:age => 18)
end

a = {:name => 'testing'}
notify(a)
puts a #=> {:name=>"testing", :age=>18}

b = {:name => 'testing'}
notify(b.dup)
puts b #=> {:name=>"testing"}
```
