### PR TITLE
Emacs notifier closes IO object instead of Array object

### DIFF
--- a/lib/guard/notifiers/emacs.rb
+++ b/lib/guard/notifiers/emacs.rb
@@ -86,7 +86,8 @@ module Guard
       private
 
       def _run_cmd(*args)
-        p = IO.popen(args).readlines
+        p = IO.popen(args)
+        p.readlines
         p.close
       end
 


### PR DESCRIPTION
Emacs notifier was attempting to close an array instead of the IO object.
