### PR TITLE
Improve groups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,13 +478,35 @@ group :docs do
 end
 ```
 
+Groups can be nested, reopened and can take muliple names to assign its plugin to multiple groups:
+
+```ruby
+group :desktop do
+  guard 'livereload' do
+    watch(%r{desktop/.+\.html})
+  end
+
+  group :mobile do
+    guard 'livereload' do
+      watch(%r{mobile/.+\.html})
+    end
+  end
+end
+
+group :mobile, :desktop do
+  guard 'livereload' do
+    watch(%r{both/.+\.html})
+  end
+end
+```
+
 Groups to be run can be specified with the Guard DSL option `--group` (or `-g`):
 
 ```bash
 $ bundle exec guard -g specs
 ```
 
-Guard plugins that don't belong to a group are considered global and are always run.
+Plugins that don't belong to a group are part of the `default` group.
 
 Another neat use of groups is to group dependant plugins and stop processing if one fails. In order
 to make this work, the group needs to have the `halt_on_fail` option enabled and the Guard plugin

--- a/lib/guard/dsl.rb
+++ b/lib/guard/dsl.rb
@@ -108,7 +108,7 @@ module Guard
     #     guard :livereload
     #   end
     #
-    # @param [Symbol, String] name the group name called from the CLI
+    # @param [Symbol, String, Array<Symbol, String>] name the group name called from the CLI
     # @param [Hash] options the options accepted by the group
     # @yield a block where you can declare several Guard plugins
     #
@@ -117,17 +117,25 @@ module Guard
     # @see #guard
     #
     def group(name, options = {})
-      raise ArgumentError, "'all' is not an allowed group name!" if name.to_sym == :all
+      groups = name.is_a?(Array) ? name : [name]
+
+      groups.each do |group|
+        raise ArgumentError, "'all' is not an allowed group name!" if group.to_sym == :all
+      end
 
       if block_given?
-        ::Guard.add_group(name, options)
-        @current_group = name
+        groups.each do |group|
+          ::Guard.add_group(group, options)
+        end
+
+        @current_groups ||= []
+        @current_groups.push(groups)
 
         yield
 
-        @current_group = nil
+        @current_groups.pop
       else
-        ::Guard::UI.error "No Guard plugins found in the group '#{ name }', please add at least one."
+        ::Guard::UI.error "No Guard plugins found in the group '#{ groups.join(', ') }', please add at least one."
       end
     end
 
@@ -158,12 +166,14 @@ module Guard
     def guard(name, options = {})
       @watchers  = []
       @callbacks = []
-      @current_group ||= :default
 
       yield if block_given?
 
-      options.merge!(group: @current_group, watchers: @watchers, callbacks: @callbacks)
-      ::Guard.add_plugin(name, options)
+      groups = @current_groups || [[:default]]
+      groups.last.each do |group|
+        options.merge!(group: group, watchers: @watchers, callbacks: @callbacks)
+        ::Guard.add_plugin(name, options)
+      end
     end
 
     # Defines a pattern to be watched in order to run actions on file modification.


### PR DESCRIPTION
This changes the way groups are remembered when evaluating the DSL,
so they can be nested more flexible and also take multiple name, so
its plugin are part of multiple groups with a single definition.

The idea comes from the following Google+ post:
https://plus.google.com/114035850232644654438/posts/HTNs9tcWVAt

My initial idea was that the shared plugins should go to the top
level, so they are part of the `default` group and always executed,
but as it turned out, this feature was broken. So instead of fixing
it, I implemented the multiple group names and updated the README.
