### PR TITLE
Upgrade to rspec 3.0.0.beta1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,6 @@ end
 # installed on Travis CI
 #
 group :test do
-  gem 'rspec', '~> 2.14'
+  gem 'rspec', '3.0.0.beta1'
   gem 'coveralls', require: false
 end

--- a/guard.gemspec
+++ b/guard.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'formatador', '>= 0.2.4'
 
   s.add_development_dependency 'bundler'
-  s.add_development_dependency 'rspec', '~> 2.14'
+  s.add_development_dependency 'rspec', '3.0.0.beta1'
 
   s.files        = Dir.glob('{bin,images,lib}/**/*') + %w[CHANGELOG.md LICENSE man/guard.1 man/guard.1.html README.md]
   s.executable   = 'guard'

--- a/spec/lib/guard/commander_spec.rb
+++ b/spec/lib/guard/commander_spec.rb
@@ -80,7 +80,7 @@ describe Guard::Commander do
     it "sets the running state to false" do
       ::Guard.running = true
       ::Guard.stop
-      expect(::Guard.running).to be_false
+      expect(::Guard.running).to be_falsey
     end
   end
 
@@ -192,7 +192,7 @@ describe Guard::Commander do
     it 'runs the passed block' do
       @called = false
       subject.within_preserved_state { @called = true }
-      expect(@called).to be_true
+      expect(@called).to be_truthy
     end
 
     context '@running is true' do

--- a/spec/lib/guard/dsl_spec.rb
+++ b/spec/lib/guard/dsl_spec.rb
@@ -118,7 +118,7 @@ describe Guard::Dsl do
 
     it 'disables the interactions with :off' do
       described_class.evaluate_guardfile(guardfile_contents: 'interactor :off')
-      expect(Guard::Interactor.enabled).to be_false
+      expect(Guard::Interactor.enabled).to be_falsey
     end
 
     it 'passes the options to the interactor' do
@@ -242,8 +242,8 @@ describe Guard::Dsl do
       end
 
       expect(::Guard).to receive(:add_plugin).with(:rspec, { watchers: [], callbacks: [anything, anything], group: :default }) do |_, options|
-        expect(options[:callbacks]).to have(2).items
-        expect(options[:callbacks][0][:events]).to    eq :start_end
+        expect(options[:callbacks].size).to eq 2
+        expect(options[:callbacks][0][:events]).to eq :start_end
         expect(options[:callbacks][0][:listener].call(Guard::RSpec, :start_end, 'foo')).to eq 'Guard::RSpec executed \'start_end\' hook with foo!'
         expect(options[:callbacks][1][:events]).to eq [:start_begin, :run_all_begin]
         expect(options[:callbacks][1][:listener]).to eq MyCustomCallback

--- a/spec/lib/guard/guardfile/evaluator_spec.rb
+++ b/spec/lib/guard/guardfile/evaluator_spec.rb
@@ -385,25 +385,25 @@ describe Guard::Guardfile::Evaluator do
     it 'detects a guard specified by a string with double quotes' do
       guardfile_evaluator.stub(_guardfile_contents_without_user_config: 'guard "test" {watch("c")}')
 
-      expect(guardfile_evaluator.guardfile_include?('test')).to be_true
+      expect(guardfile_evaluator.guardfile_include?('test')).to be_truthy
     end
 
     it 'detects a guard specified by a string with single quote' do
       guardfile_evaluator.stub(_guardfile_contents_without_user_config: 'guard \'test\' {watch("c")}')
 
-      expect(guardfile_evaluator.guardfile_include?('test')).to be_true
+      expect(guardfile_evaluator.guardfile_include?('test')).to be_truthy
     end
 
     it 'detects a guard specified by a symbol' do
       guardfile_evaluator.stub(_guardfile_contents_without_user_config: 'guard :test {watch("c")}')
 
-      expect(guardfile_evaluator.guardfile_include?('test')).to be_true
+      expect(guardfile_evaluator.guardfile_include?('test')).to be_truthy
     end
 
     it 'detects a guard wrapped in parentheses' do
       guardfile_evaluator.stub(_guardfile_contents_without_user_config: 'guard(:test) {watch("c")}')
 
-      expect(guardfile_evaluator.guardfile_include?('test')).to be_true
+      expect(guardfile_evaluator.guardfile_include?('test')).to be_truthy
     end
   end
 

--- a/spec/lib/guard/guardfile/generator_spec.rb
+++ b/spec/lib/guard/guardfile/generator_spec.rb
@@ -6,7 +6,7 @@ describe Guard::Guardfile::Generator do
   let(:guardfile_generator) { described_class.new }
 
   it "has a valid Guardfile template" do
-    expect(File.exists?(described_class::GUARDFILE_TEMPLATE)).to be_true
+    expect(File.exists?(described_class::GUARDFILE_TEMPLATE)).to be_truthy
   end
 
   describe '#create_guardfile' do

--- a/spec/lib/guard/interactor_spec.rb
+++ b/spec/lib/guard/interactor_spec.rb
@@ -11,14 +11,14 @@ describe Guard::Interactor do
     after { described_class.enabled = @interactor_enabled }
 
     it 'returns true by default' do
-      expect(described_class.enabled).to be_true
+      expect(described_class.enabled).to be_truthy
     end
 
     context 'interactor not enabled' do
       before { described_class.enabled = false }
 
       it 'returns false' do
-        expect(described_class.enabled).to be_false
+        expect(described_class.enabled).to be_falsey
       end
     end
   end

--- a/spec/lib/guard/notifiers/base_spec.rb
+++ b/spec/lib/guard/notifiers/base_spec.rb
@@ -147,7 +147,7 @@ describe Guard::Notifier::Base do
       it 'returns true' do
         expect(Guard::Notifier::FooBar).to receive(:require).with('foo_bar')
 
-        expect(Guard::Notifier::FooBar.require_gem_safely).to be_true
+        expect(Guard::Notifier::FooBar.require_gem_safely).to be_truthy
       end
     end
 
@@ -156,7 +156,7 @@ describe Guard::Notifier::Base do
         expect(::Guard::UI).to receive(:error).with "Please add \"gem 'foo_bar'\" to your Gemfile and run Guard with \"bundle exec\"."
         expect(Guard::Notifier::FooBar).to receive(:require).with('foo_bar').and_raise LoadError
 
-        expect(Guard::Notifier::FooBar.require_gem_safely).to be_false
+        expect(Guard::Notifier::FooBar.require_gem_safely).to be_falsey
       end
 
       context 'with the silent option' do
@@ -164,7 +164,7 @@ describe Guard::Notifier::Base do
           expect(::Guard::UI).to_not receive(:error).with "Please add \"gem 'growl_notify'\" to your Gemfile and run Guard with \"bundle exec\"."
           expect(Guard::Notifier::FooBar).to receive(:require).with('foo_bar').and_raise LoadError
 
-          expect(Guard::Notifier::FooBar.require_gem_safely(silent: true)).to be_false
+          expect(Guard::Notifier::FooBar.require_gem_safely(silent: true)).to be_falsey
         end
       end
     end

--- a/spec/lib/guard/notifiers/emacs_spec.rb
+++ b/spec/lib/guard/notifiers/emacs_spec.rb
@@ -16,7 +16,7 @@ describe Guard::Notifier::Emacs do
       let(:notifier) { described_class.new(success: 'Green', silent: true) }
 
       it 'uses these options by default' do
-        notifier.should_receive(:_run_cmd).with do |*command|
+        notifier.should_receive(:_run_cmd) do |*command|
           expect(command).to include("emacsclient")
           expect(command).to include(%{(set-face-attribute 'mode-line nil :background "Green" :foreground "White")})
         end
@@ -25,7 +25,7 @@ describe Guard::Notifier::Emacs do
       end
 
       it 'overwrites object options with passed options' do
-        notifier.should_receive(:_run_cmd).with do |*command|
+        notifier.should_receive(:_run_cmd) do |*command|
           expect(command).to include("emacsclient")
           expect(command).to include(%{(set-face-attribute 'mode-line nil :background "LightGreen" :foreground "White")})
         end
@@ -36,7 +36,7 @@ describe Guard::Notifier::Emacs do
 
     context 'when no color options are specified' do
       it 'should set modeline color to the default color using emacsclient' do
-        notifier.should_receive(:_run_cmd).with do |*command|
+        notifier.should_receive(:_run_cmd) do |*command|
           expect(command).to include("emacsclient")
           expect(command).to include(%{(set-face-attribute 'mode-line nil :background "ForestGreen" :foreground "White")})
         end
@@ -47,7 +47,7 @@ describe Guard::Notifier::Emacs do
 
     context 'when a color option is specified for "success" notifications' do
       it 'should set modeline color to the specified color using emacsclient' do
-        notifier.should_receive(:_run_cmd).with do |*command|
+        notifier.should_receive(:_run_cmd) do |*command|
           expect(command).to include("emacsclient")
           expect(command).to include(%{(set-face-attribute 'mode-line nil :background "Orange" :foreground "White")})
         end
@@ -58,7 +58,7 @@ describe Guard::Notifier::Emacs do
 
     context 'when a color option is specified for "pending" notifications' do
       it 'should set modeline color to the specified color using emacsclient' do
-        notifier.should_receive(:_run_cmd).with do |*command|
+        notifier.should_receive(:_run_cmd) do |*command|
           expect(command).to include("emacsclient")
           expect(command).to include(%{(set-face-attribute 'mode-line nil :background "Yellow" :foreground "White")})
         end

--- a/spec/lib/guard/notifiers/notifysend_spec.rb
+++ b/spec/lib/guard/notifiers/notifysend_spec.rb
@@ -38,7 +38,7 @@ describe Guard::Notifier::NotifySend do
       let(:notifier) { described_class.new(image: '/tmp/hello.png', silent: true) }
 
       it 'uses these options by default' do
-        notifier.should_receive(:system).with do |command, *arguments|
+        notifier.should_receive(:system) do |command, *arguments|
           expect(command).to eql 'notify-send'
           expect(arguments).to include '-i', '/tmp/hello.png'
           expect(arguments).to include '-u', 'low'
@@ -50,7 +50,7 @@ describe Guard::Notifier::NotifySend do
       end
 
       it 'overwrites object options with passed options' do
-        notifier.should_receive(:system).with do |command, *arguments|
+        notifier.should_receive(:system) do |command, *arguments|
           expect(command).to eql 'notify-send'
           expect(arguments).to include '-i', '/tmp/welcome.png'
           expect(arguments).to include '-u', 'low'
@@ -62,7 +62,7 @@ describe Guard::Notifier::NotifySend do
       end
 
       it 'uses the title provided in the options' do
-        notifier.should_receive(:system).with do |command, *arguments|
+        notifier.should_receive(:system) do |command, *arguments|
           expect(command).to eql 'notify-send'
           expect(arguments).to include 'Welcome to Guard'
           expect(arguments).to include 'test title'
@@ -73,7 +73,7 @@ describe Guard::Notifier::NotifySend do
 
     context 'without additional options' do
       it 'shows the notification with the default options' do
-        notifier.should_receive(:system).with do |command, *arguments|
+        notifier.should_receive(:system) do |command, *arguments|
           expect(command).to eql 'notify-send'
           expect(arguments).to include '-i', '/tmp/welcome.png'
           expect(arguments).to include '-u', 'low'
@@ -87,7 +87,7 @@ describe Guard::Notifier::NotifySend do
 
     context 'with additional options' do
       it 'can override the default options' do
-        notifier.should_receive(:system).with do |command, *arguments|
+        notifier.should_receive(:system) do |command, *arguments|
           expect(command).to eql 'notify-send'
           expect(arguments).to include '-i', '/tmp/wait.png'
           expect(arguments).to include '-u', 'critical'

--- a/spec/lib/guard/plugin/hooker_spec.rb
+++ b/spec/lib/guard/plugin/hooker_spec.rb
@@ -38,20 +38,20 @@ describe Guard::Plugin::Hooker do
 
   describe '.add_callback' do
     it 'can add a single callback' do
-      expect(described_class.callbacks[[dummy1, :start_begin]].include?(listener)).to be_true
+      expect(described_class.callbacks[[dummy1, :start_begin]].include?(listener)).to be_truthy
     end
 
     it 'can add a run_on_modifications callback' do
       described_class.add_callback(listener, dummy1, :run_on_modifications_begin)
 
-      expect(described_class.callbacks[[dummy1, :run_on_modifications_begin]].include?(listener)).to be_true
+      expect(described_class.callbacks[[dummy1, :run_on_modifications_begin]].include?(listener)).to be_truthy
     end
 
     it 'can add multiple callbacks' do
       described_class.add_callback(listener, dummy1, [:event1, :event2])
 
-      expect(described_class.callbacks[[dummy1, :event1]].include?(listener)).to be_true
-      expect(described_class.callbacks[[dummy1, :event2]].include?(listener)).to be_true
+      expect(described_class.callbacks[[dummy1, :event1]].include?(listener)).to be_truthy
+      expect(described_class.callbacks[[dummy1, :event2]].include?(listener)).to be_truthy
     end
   end
 

--- a/spec/lib/guard/runner_spec.rb
+++ b/spec/lib/guard/runner_spec.rb
@@ -295,7 +295,7 @@ describe Guard::Runner do
         end
 
         it 'returns the result of the task' do
-          expect(subject.run_supervised_task(@foo_guard, :regular_without_arg)).to be_true
+          expect(subject.run_supervised_task(@foo_guard, :regular_without_arg)).to be_truthy
         end
 
         it 'passes the args to the :begin hook' do

--- a/spec/lib/guard/setuper_spec.rb
+++ b/spec/lib/guard/setuper_spec.rb
@@ -29,7 +29,7 @@ describe Guard::Setuper do
     end
 
     it 'lazily initializes the options' do
-      expect(subject.options[:my_opts]).to be_true
+      expect(subject.options[:my_opts]).to be_truthy
     end
 
     it 'lazily initializes the evaluator' do
@@ -151,7 +151,7 @@ describe Guard::Setuper do
     it "initializes a default group" do
       subject.reset_groups
 
-      expect(subject.groups).to have(1).item
+      expect(subject.groups.size).to eq 1
       expect(subject.groups[0].name).to eq :default
       expect(subject.groups[0].options).to eq({})
     end
@@ -171,7 +171,7 @@ describe Guard::Setuper do
     end
 
     it "return clear the plugins array" do
-      expect(subject.plugins).to have(1).item
+      expect(subject.plugins.size).to eq 1
 
       subject.reset_plugins
 
@@ -468,7 +468,7 @@ describe Guard::Setuper do
       subject.send :_debug_command_execution
       expect(Kernel).to receive(:original_system).with('echo', 'test').and_return true
 
-      expect(system('echo', 'test')).to be_true
+      expect(system('echo', 'test')).to be_truthy
     end
 
     it "outputs Kernel.#` method parameters" do

--- a/spec/lib/guard/watcher_spec.rb
+++ b/spec/lib/guard/watcher_spec.rb
@@ -122,7 +122,7 @@ describe Guard::Watcher do
 
         it "returns a single file specified within the action" do
           expect(described_class.match_files(@guard_plugin_any_return, ['spec_helper.rb']).class).to be Array
-          expect(described_class.match_files(@guard_plugin_any_return, ['spec_helper.rb']).empty?).to be_false
+          expect(described_class.match_files(@guard_plugin_any_return, ['spec_helper.rb']).empty?).to be_falsey
         end
 
         it "returns multiple files specified within the action" do
@@ -246,11 +246,11 @@ describe Guard::Watcher do
     end
 
     context "with a watcher that matches a file" do
-      specify { expect(described_class.match_files?(@plugins, ['lib/my_wonderful_lib.rb', 'guard_rocks_spec.rb'])).to be_true }
+      specify { expect(described_class.match_files?(@plugins, ['lib/my_wonderful_lib.rb', 'guard_rocks_spec.rb'])).to be_truthy }
     end
 
     context "with no watcher that matches a file" do
-      specify { expect(described_class.match_files?(@plugins, ['lib/my_wonderful_lib.rb'])).to be_false }
+      specify { expect(described_class.match_files?(@plugins, ['lib/my_wonderful_lib.rb'])).to be_falsey }
     end
   end
 
@@ -334,11 +334,11 @@ describe Guard::Watcher do
     before { Guard.stub(:evaluator) { double(guardfile_path: File.expand_path('Guardfile')) } }
 
     context "with files that match the Guardfile" do
-      specify { expect(described_class.match_guardfile?(['Guardfile', 'guard_rocks_spec.rb'])).to be_true }
+      specify { expect(described_class.match_guardfile?(['Guardfile', 'guard_rocks_spec.rb'])).to be_truthy }
     end
 
     context "with no files that match the Guardfile" do
-      specify { expect(described_class.match_guardfile?(['guard_rocks.rb', 'guard_rocks_spec.rb'])).to be_false }
+      specify { expect(described_class.match_guardfile?(['guard_rocks.rb', 'guard_rocks_spec.rb'])).to be_falsey }
     end
   end
 


### PR DESCRIPTION
I upgraded your specs to rspec 3.0.0.beta1. I'm not sure that you're interested in being on the edge, but if not then at least this should serve in the migration to 3.0.0 proper.
