### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,12 +197,12 @@ $ bundle exec guard -g group_name another_group_name # shortcut
 
 See the Guardfile DSL below for creating groups.
 
-#### `-P`/`--plugins` option
+#### `-P`/`--plugin` option
 
 Scope Guard to certain plugins on start:
 
 ```bash
-$ bundle exec guard --plugins plugin_name another_plugin_name
+$ bundle exec guard --plugin plugin_name another_plugin_name
 $ bundle exec guard -P plugin_name another_plugin_name # shortcut
 ```
 


### PR DESCRIPTION
Replace 'bundle exec guard --plugins' with bundle exec guard --plugin'.

The plural version results in an error like:
ERROR: guard start was called with arguments ["--plugins", "plugin1", "plugin2"]
Usage: "guard start".
