### PR TITLE
Change Ruby version from 1.9.2 to 1.9.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ guard :bundler do
 end
 ```
 
-String watch patterns are matched with [String#==](http://www.ruby-doc.org/core-1.9.2/String.html#method-i-3D-3D).
+String watch patterns are matched with [String#==](http://www.ruby-doc.org/core-1.9.3/String.html#method-i-3D-3D).
 You can also pass a regular expression to the watch method:
 
 ```ruby
@@ -462,7 +462,7 @@ end
 
 In this example the regular expression capture group `(.+)` is used to transform a file change
 in the `lib` folder to its test case in the `spec` folder. Regular expression watch patterns
-are matched with [Regexp#match](http://www.ruby-doc.org/core-1.9.2/Regexp.html#method-i-match).
+are matched with [Regexp#match](http://www.ruby-doc.org/core-1.9.3/Regexp.html#method-i-match).
 
 You can also launch any arbitrary command in the supplied block:
 

--- a/guard.gemspec
+++ b/guard.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Guard keeps an eye on your file modifications'
   s.description = 'Guard is a command line tool to easily handle events on file system modifications.'
 
-  s.required_ruby_version = '>= 1.9.2'
+  s.required_ruby_version = '>= 1.9.3'
 
   s.add_runtime_dependency 'thor',       '>= 0.18.1'
   s.add_runtime_dependency 'listen',     '~> 2.1'


### PR DESCRIPTION
Support for Ruby 1.9.2 was removed from on Sep 17, 2013:
https://github.com/guard/guard/commit/17f32f8000f8e02e6ad4c3a46f7125582b2f6c4c
