### PR TITLE
remove a spec_helper option

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,6 @@ RSpec.configure do |config|
   config.color_enabled = true
   config.order = :random
   config.filter_run focus: ENV['CI'] != 'true'
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.expect_with :rspec do |c|
     c.syntax = :expect


### PR DESCRIPTION
I removed option `treat_symbols_as_metadata_keys_with_true_values` from spec_helper.
It is because in rspec3.0, the option, `treat_symbols_as_metadata_keys_with_true_values` is always true (treat_symbols_as_metadata_keys_with_true_values = false is depreceted)
