### PR TITLE
Fixes #turn_on and #turn_off for tmux notifier

### DIFF
--- a/lib/guard/notifiers/tmux.rb
+++ b/lib/guard/notifiers/tmux.rb
@@ -204,7 +204,7 @@ module Guard
       # Notification starting, save the current Tmux settings
       # and quiet the Tmux output.
       #
-      def turn_on
+      def self.turn_on
         unless @options_stored
           _reset_options_store
           _clients.each do |client|
@@ -222,7 +222,7 @@ module Guard
       # if available (existing options are restored, new options
       # are unset) and unquiet the Tmux output.
       #
-      def turn_off
+      def self.turn_off
         if @options_stored
           @options_store.each do |client, options|
             options.each do |key, value|
@@ -237,7 +237,7 @@ module Guard
         end
       end
 
-      def options_store
+      def self.options_store
         @options_store ||= {}
       end
 
@@ -248,8 +248,12 @@ module Guard
         super
       end
 
-      def _clients
+      def self._clients
         %x( #{DEFAULTS[:client]} list-clients -F '\#{client_tty}').split(/\n/);
+      end
+
+      def _clients
+        self.class._client
       end
 
       def _run_client(cmd, args)
@@ -271,7 +275,7 @@ module Guard
 
       # Reset the internal Tmux options store defaults.
       #
-      def _reset_options_store
+      def self._reset_options_store
         @options_stored = false
         @options_store = {}
         _clients.each do | client |
@@ -284,14 +288,6 @@ module Guard
             'message-fg'      => nil,
             'display-time'    => nil
           }
-        end
-      end
-
-      # Remove clients which no longer exist from options store
-      #
-      def _remove_old_clients
-        (options_store.keys - _clients).each do | old_client |
-          options_store.delete old_client
         end
       end
 

--- a/spec/lib/guard/notifiers/tmux_spec.rb
+++ b/spec/lib/guard/notifiers/tmux_spec.rb
@@ -275,102 +275,102 @@ describe Guard::Notifier::Tmux do
 
   end
 
-  describe '.turn_on' do
+  describe '#turn_on' do
     before do
-      notifier.stub(:`).and_return("option1 setting1\noption2 setting2\n")
-      notifier.stub(:_clients).and_return(['tty'])
-      notifier.stub system: true
+      described_class.stub(:`).and_return("option1 setting1\noption2 setting2\n")
+      described_class.stub(:_clients).and_return(['tty'])
+      described_class.stub system: true
     end
 
     context 'when off' do
       before do
-        notifier.turn_off
+        described_class.turn_off
       end
 
       it 'resets the options store' do
-        expect(notifier).to receive(:_reset_options_store)
+        expect(described_class).to receive(:_reset_options_store)
 
-        notifier.turn_on
+        described_class.turn_on
       end
 
       it 'saves the current tmux options' do
-        expect(notifier).to receive(:`).with('tmux show -t tty')
+        expect(described_class).to receive(:`).with('tmux show -t tty')
 
-        notifier.turn_on
+        described_class.turn_on
       end
     end
 
     context 'when on' do
       before do
-        notifier.turn_on
+        described_class.turn_on
       end
 
       it 'does not reset the options store' do
-        expect(notifier).to_not receive(:_reset_options_store)
+        expect(described_class).to_not receive(:_reset_options_store)
 
-        notifier.turn_on
+        described_class.turn_on
       end
 
       it 'does not save the current tmux options' do
-        expect(notifier).to_not receive(:`).with('tmux show')
+        expect(described_class).to_not receive(:`).with('tmux show')
 
-        notifier.turn_on
+        described_class.turn_on
       end
     end
   end
 
-  describe '.turn_off' do
+  describe '#turn_off' do
     before do
-      notifier.stub(:`).and_return("option1 setting1\noption2 setting2\n")
-      notifier.stub(:_clients).and_return(['tty'])
-      notifier.stub system: true
+      described_class.stub(:`).and_return("option1 setting1\noption2 setting2\n")
+      described_class.stub(:_clients).and_return(['tty'])
+      described_class.stub system: true
     end
 
     context 'when on' do
       before do
-        notifier.turn_on
+        described_class.turn_on
       end
 
       it 'restores the tmux options' do
-        expect(notifier).to receive(:`).with('tmux set -t tty -q option2 setting2')
-        expect(notifier).to receive(:`).with('tmux set -t tty -q -u status-left-bg')
-        expect(notifier).to receive(:`).with('tmux set -t tty -q option1 setting1')
-        expect(notifier).to receive(:`).with('tmux set -t tty -q -u status-right-bg')
-        expect(notifier).to receive(:`).with('tmux set -t tty -q -u status-right-fg')
-        expect(notifier).to receive(:`).with('tmux set -t tty -q -u status-left-fg')
-        expect(notifier).to receive(:`).with('tmux set -t tty -q -u message-fg')
-        expect(notifier).to receive(:`).with('tmux set -t tty -q -u message-bg')
+        expect(described_class).to receive(:`).with('tmux set -t tty -q option2 setting2')
+        expect(described_class).to receive(:`).with('tmux set -t tty -q -u status-left-bg')
+        expect(described_class).to receive(:`).with('tmux set -t tty -q option1 setting1')
+        expect(described_class).to receive(:`).with('tmux set -t tty -q -u status-right-bg')
+        expect(described_class).to receive(:`).with('tmux set -t tty -q -u status-right-fg')
+        expect(described_class).to receive(:`).with('tmux set -t tty -q -u status-left-fg')
+        expect(described_class).to receive(:`).with('tmux set -t tty -q -u message-fg')
+        expect(described_class).to receive(:`).with('tmux set -t tty -q -u message-bg')
 
-        notifier.turn_off
+        described_class.turn_off
       end
 
       it 'resets the options store' do
-        expect(notifier).to receive(:_reset_options_store)
+        expect(described_class).to receive(:_reset_options_store)
 
-        notifier.turn_off
+        described_class.turn_off
       end
     end
 
     context 'when off' do
       before do
-        notifier.turn_off
+        described_class.turn_off
       end
 
       it 'does not restore the tmux options' do
-        expect(notifier).to_not receive(:system).with('tmux set -q -u status-left-bg')
-        expect(notifier).to_not receive(:system).with('tmux set -q -u status-right-bg')
-        expect(notifier).to_not receive(:system).with('tmux set -q -u status-right-fg')
-        expect(notifier).to_not receive(:system).with('tmux set -q -u status-left-fg')
-        expect(notifier).to_not receive(:system).with('tmux set -q -u message-fg')
-        expect(notifier).to_not receive(:system).with('tmux set -q -u message-bg')
+        expect(described_class).to_not receive(:system).with('tmux set -q -u status-left-bg')
+        expect(described_class).to_not receive(:system).with('tmux set -q -u status-right-bg')
+        expect(described_class).to_not receive(:system).with('tmux set -q -u status-right-fg')
+        expect(described_class).to_not receive(:system).with('tmux set -q -u status-left-fg')
+        expect(described_class).to_not receive(:system).with('tmux set -q -u message-fg')
+        expect(described_class).to_not receive(:system).with('tmux set -q -u message-bg')
 
-        notifier.turn_off
+        described_class.turn_off
       end
 
       it 'does not reset the options store' do
-        expect(notifier).to_not receive(:_reset_options_store)
+        expect(described_class).to_not receive(:_reset_options_store)
 
-        notifier.turn_off
+        described_class.turn_off
       end
     end
   end


### PR DESCRIPTION
The tmux's facility for restoring colors was broken
because the `turn_on()` and `turn_off()` methods are now
class methods.

fixes #539
