### PR TITLE
Ignore tags file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ coverage/
 .tm_properties
 man/guard
 man/guard.html
+/tags


### PR DESCRIPTION
I use ctags to navigate my ruby code and it stores a
file in the root of the project called `tags`.  This
ignores it.
