### PR TITLE
RSpec 3.0 syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'rake'
 group :development, :test do
   # This plugin is required in the tests!
   gem 'guard-rspec', require: false
+  gem 'rspec', '>= 3.0.0.beta2'
 end
 
 # The development group will no be

--- a/spec/guard_spec.rb
+++ b/spec/guard_spec.rb
@@ -222,7 +222,7 @@ describe Guard do
 
     before do
       expect(::Guard::PluginUtil).to receive(:new).with('rspec') { plugin_util }
-      plugin_util.stub(:initialize_plugin) { guard_rspec }
+      allow(plugin_util).to receive(:initialize_plugin) { guard_rspec }
 
       ::Guard.reset_plugins
     end

--- a/spec/lib/guard/cli_spec.rb
+++ b/spec/lib/guard/cli_spec.rb
@@ -7,7 +7,7 @@ describe Guard::CLI do
   let(:dsl_describer) { double('DslDescriber instance') }
 
   describe '#start' do
-    before { Guard.stub(:start) }
+    before { allow(Guard).to receive(:start) }
 
     it 'delegates to Guard.start' do
       expect(Guard).to receive(:start)
@@ -17,7 +17,7 @@ describe Guard::CLI do
 
     context 'with a Gemfile in the project dir' do
       before do
-        File.stub(:exists?).with('Gemfile').and_return true
+        allow(File).to receive(:exists?).with('Gemfile').and_return(true)
       end
 
       context 'when running with Bundler' do
@@ -101,9 +101,9 @@ describe Guard::CLI do
     let(:options) { { bare: false } }
 
     before do
-      subject.stub(options: options)
-      Guard::Guardfile.stub(:create_guardfile)
-      Guard::Guardfile.stub(:initialize_all_templates)
+      allow(subject).to receive(:options).and_return(options)
+      allow(Guard::Guardfile).to receive(:create_guardfile)
+      allow(Guard::Guardfile).to receive(:initialize_all_templates)
     end
 
     it 'creates a Guardfile by delegating to Guardfile.create_guardfile' do

--- a/spec/lib/guard/commands/all_spec.rb
+++ b/spec/lib/guard/commands/all_spec.rb
@@ -8,9 +8,9 @@ describe 'Guard::Interactor::ALL' do
   let(:bar_guard) { guard.add_plugin(:bar, group: :foo) }
 
   before do
-    Guard.stub(:run_all)
-    Guard.stub(:setup_interactor)
-    Pry.output.stub(:puts)
+    allow(Guard).to receive(:run_all)
+    allow(Guard).to receive(:setup_interactor)
+    allow(Pry.output).to receive(:puts)
     stub_const 'Guard::Bar', Class.new(Guard::Plugin)
   end
 

--- a/spec/lib/guard/commands/change_spec.rb
+++ b/spec/lib/guard/commands/change_spec.rb
@@ -4,8 +4,8 @@ describe 'Guard::Interactor::CHANGE' do
 
   before do
     ::Guard.setup
-    Guard.runner.stub(:run_on_changes)
-    Pry.output.stub(:puts)
+    allow(Guard.runner).to receive(:run_on_changes)
+    allow(Pry.output).to receive(:puts)
   end
 
   describe '#perform' do

--- a/spec/lib/guard/commands/notification_spec.rb
+++ b/spec/lib/guard/commands/notification_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Guard::Interactor::NOTIFICATION' do
 
   before do
-    ::Guard::Notifier.stub(:toggle)
+    allow(::Guard::Notifier).to receive(:toggle)
   end
 
   describe '#perform' do

--- a/spec/lib/guard/commands/pause_spec.rb
+++ b/spec/lib/guard/commands/pause_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Guard::Interactor::PAUSE' do
 
   before do
-    ::Guard::stub(:pause)
+    allow(::Guard).to receive(:pause)
   end
 
   describe '#perform' do

--- a/spec/lib/guard/commands/reload_spec.rb
+++ b/spec/lib/guard/commands/reload_spec.rb
@@ -8,9 +8,9 @@ describe 'Guard::Interactor::RELOAD' do
   let(:bar_guard) { guard.add_plugin(:bar, group: :foo) }
 
   before do
-    Guard.stub(:reload)
-    Guard.stub(:setup_interactor)
-    Pry.output.stub(:puts)
+    allow(Guard).to receive(:reload)
+    allow(Guard).to receive(:setup_interactor)
+    allow(Pry.output).to receive(:puts)
     stub_const 'Guard::Bar', Class.new(Guard::Plugin)
   end
 

--- a/spec/lib/guard/commands/scope_spec.rb
+++ b/spec/lib/guard/commands/scope_spec.rb
@@ -8,9 +8,9 @@ describe 'Guard::Interactor::SCOPE' do
   let(:bar_guard) { guard.add_plugin(:bar, group: :foo) }
 
   before do
-    Guard.stub(:scope=)
-    Guard.stub(:setup_interactor)
-    Pry.output.stub(puts: true)
+    allow(Guard).to receive(:scope=)
+    allow(Guard).to receive(:setup_interactor)
+    allow(Pry.output).to receive(:puts).and_return(true)
     stub_const 'Guard::Bar', Class.new(Guard::Plugin)
   end
 

--- a/spec/lib/guard/deprecated_methods_spec.rb
+++ b/spec/lib/guard/deprecated_methods_spec.rb
@@ -8,7 +8,7 @@ describe Guard::DeprecatedMethods do
   end
 
   describe '.guards' do
-    before { TestModule.stub(:plugins) }
+    before { allow(TestModule).to receive(:plugins) }
 
     it 'displays a deprecation warning to the user' do
       expect(::Guard::UI).to receive(:deprecation).with(::Guard::Deprecator::GUARDS_DEPRECATION)
@@ -24,7 +24,7 @@ describe Guard::DeprecatedMethods do
   end
 
   describe '.add_guard' do
-    before { TestModule.stub(:add_plugin) }
+    before { allow(TestModule).to receive(:add_plugin) }
 
     it 'displays a deprecation warning to the user' do
       expect(::Guard::UI).to receive(:deprecation).with(::Guard::Deprecator::ADD_GUARD_DEPRECATION)
@@ -41,7 +41,7 @@ describe Guard::DeprecatedMethods do
 
   describe '.get_guard_class' do
     let(:plugin_util) { double('Guard::PluginUtil', plugin_class: true) }
-    before { ::Guard::PluginUtil.stub(:new).and_return(plugin_util) }
+    before { allow(::Guard::PluginUtil).to receive(:new).and_return(plugin_util) }
 
     it 'displays a deprecation warning to the user' do
       expect(::Guard::UI).to receive(:deprecation).with(::Guard::Deprecator::GET_GUARD_CLASS_DEPRECATION)
@@ -68,7 +68,7 @@ describe Guard::DeprecatedMethods do
 
   describe '.locate_guard' do
     let(:plugin_util) { double('Guard::PluginUtil', plugin_location: true) }
-    before { ::Guard::PluginUtil.stub(:new).and_return(plugin_util) }
+    before { allow(::Guard::PluginUtil).to receive(:new).and_return(plugin_util) }
 
     it 'displays a deprecation warning to the user' do
       expect(::Guard::UI).to receive(:deprecation).with(::Guard::Deprecator::LOCATE_GUARD_DEPRECATION)
@@ -85,7 +85,7 @@ describe Guard::DeprecatedMethods do
   end
 
   describe '.guard_gem_names' do
-    before { ::Guard::PluginUtil.stub(:plugin_names) }
+    before { allow(::Guard::PluginUtil).to receive(:plugin_names) }
 
     it 'displays a deprecation warning to the user' do
       expect(::Guard::UI).to receive(:deprecation).with(::Guard::Deprecator::GUARD_GEM_NAMES_DEPRECATION)

--- a/spec/lib/guard/dsl_describer_spec.rb
+++ b/spec/lib/guard/dsl_describer_spec.rb
@@ -38,11 +38,11 @@ describe Guard::DslDescriber do
     @output = ''
 
     # Strip escape sequences
-    STDOUT.stub(:tty?).and_return false
+    allow(STDOUT).to receive(:tty?).and_return(false)
 
     # Capture formatador output
     Thread.current[:formatador] = Formatador.new
-    Thread.current[:formatador].stub(:print) do |msg|
+    allow(Thread.current[:formatador]).to receive(:print) do |msg|
       @output << msg
     end
   end
@@ -62,7 +62,7 @@ describe Guard::DslDescriber do
     end
 
     before do
-      ::Guard::PluginUtil.stub(:plugin_names).and_return %w(test another even more)
+      allow(::Guard::PluginUtil).to receive(:plugin_names).and_return %w(test another even more)
     end
 
     it 'lists the available Guards when they\'re declared as strings or symbols' do
@@ -113,10 +113,10 @@ describe Guard::DslDescriber do
         { terminal_title: ::Guard::Notifier::TerminalTitle }
       ]
 
-      ::Guard::Notifier::GNTP.stub(:available?).and_return true
-      ::Guard::Notifier::TerminalTitle.stub(:available?).and_return false
+      allow(::Guard::Notifier::GNTP).to receive(:available?).and_return true
+      allow(::Guard::Notifier::TerminalTitle).to receive(:available?).and_return false
 
-      ::Guard::Notifier.stub(:notifiers).and_return [
+      allow(::Guard::Notifier).to receive(:notifiers).and_return [
         { name: :gntp, options: { sticky: true } }
       ]
     end

--- a/spec/lib/guard/dsl_spec.rb
+++ b/spec/lib/guard/dsl_spec.rb
@@ -11,12 +11,12 @@ describe Guard::Dsl do
     stub_const 'Guard::Foo', Class.new(Guard::Plugin)
     stub_const 'Guard::Bar', Class.new(Guard::Plugin)
     stub_const 'Guard::Baz', Class.new(Guard::Plugin)
-    ::Guard.stub(:setup_interactor)
+    allow(::Guard).to receive(:setup_interactor)
     ::Guard.setup
   end
 
   def self.disable_user_config
-    before { File.stub(:exist?).with(home_config) { false } }
+    before { allow(File).to receive(:exist?).with(home_config).and_return(false) }
   end
 
   describe '.evaluate_guardfile' do
@@ -39,7 +39,7 @@ describe Guard::Dsl do
     let(:listener) { double }
 
     it 'adds ignored regexps to the listener' do
-      ::Guard.stub(:listener) { listener }
+      allow(::Guard).to receive(:listener) { listener }
       expect(::Guard.listener).to receive(:ignore).with([/^foo/,/bar/]) { listener }
 
       described_class.evaluate_guardfile(guardfile_contents: 'ignore %r{^foo}, /bar/')
@@ -51,15 +51,15 @@ describe Guard::Dsl do
     let(:listener) { double }
 
     it 'replaces ignored regexps in the listener' do
-      ::Guard.stub(:listener) { listener }
+      allow(::Guard).to receive(:listener) { listener }
       expect(::Guard.listener).to receive(:ignore!).with([[/^foo/,/bar/]]) { listener }
 
       described_class.evaluate_guardfile(guardfile_contents: 'ignore! %r{^foo}, /bar/')
     end
 
     it 'replaces ignored regexps in the listener but keeps these setted by filter!' do
-      ::Guard.stub(:listener) { listener }
-      ::Guard.listener.stub(:ignore!)
+      allow(::Guard).to receive(:listener) { listener }
+      allow(::Guard.listener).to receive(:ignore!)
       expect(::Guard.listener).to receive(:ignore!).with([[/.txt$/, /.*.zip/], [/^foo/]]) { listener }
 
       described_class.evaluate_guardfile(guardfile_contents: "filter! %r{.txt$}, /.*.zip/\n ignore! %r{^foo}")
@@ -71,7 +71,7 @@ describe Guard::Dsl do
     let(:listener) { double }
 
     it 'adds ignored regexps to the listener' do
-      ::Guard.stub(:listener) { listener }
+      allow(::Guard).to receive(:listener) { listener }
       expect(::Guard.listener).to receive(:ignore).with([/.txt$/, /.*.zip/]) { listener }
 
       described_class.evaluate_guardfile(guardfile_contents: 'filter %r{.txt$}, /.*.zip/')
@@ -83,15 +83,15 @@ describe Guard::Dsl do
     let(:listener) { double }
 
     it 'replaces ignored regexps in the listener' do
-      ::Guard.stub(:listener) { listener }
+      allow(::Guard).to receive(:listener) { listener }
       expect(::Guard.listener).to receive(:ignore!).with([[/.txt$/, /.*.zip/]]) { listener }
 
       described_class.evaluate_guardfile(guardfile_contents: 'filter! %r{.txt$}, /.*.zip/')
     end
 
     it 'replaces ignored regexps in the listener but keeps these setted by ignore!' do
-      ::Guard.stub(:listener) { listener }
-      ::Guard.listener.stub(:ignore!)
+      allow(::Guard).to receive(:listener) { listener }
+      allow(::Guard.listener).to receive(:ignore!)
       expect(::Guard.listener).to receive(:ignore!).with([[/^foo/], [/.txt$/, /.*.zip/]]) { listener }
 
       described_class.evaluate_guardfile(guardfile_contents: "ignore! %r{^foo}\n filter! %r{.txt$}, /.*.zip/")

--- a/spec/lib/guard/guardfile/evaluator_spec.rb
+++ b/spec/lib/guard/guardfile/evaluator_spec.rb
@@ -7,13 +7,13 @@ describe Guard::Guardfile::Evaluator do
   let(:home_config) { File.expand_path(File.join('~', '.guard.rb')) }
   let(:guardfile_evaluator) { described_class.new }
   before do
-    ::Guard.stub(:setup_interactor)
+    allow(::Guard).to receive(:setup_interactor)
     ::Guard.setup
-    ::Guard::Notifier.stub(:notify)
+    allow(::Guard::Notifier).to receive(:notify)
   end
 
   def self.disable_user_config
-    before { File.stub(:exist?).with(home_config) { false } }
+    before { allow(File).to receive(:exist?).with(home_config) { false } }
   end
 
   describe '.initialize' do
@@ -61,7 +61,7 @@ describe Guard::Guardfile::Evaluator do
       end
 
       context 'with a problem reading a Guardfile' do
-        before { File.stub(:read).with(File.expand_path('Guardfile')) { raise Errno::EACCES.new('permission error') } }
+        before { allow(File).to receive(:read).with(File.expand_path('Guardfile')) { raise Errno::EACCES.new('permission error') } }
 
         it 'displays an error message and exits' do
           expect(Guard::UI).to receive(:error).with(/^Error reading file/)
@@ -98,7 +98,9 @@ describe Guard::Guardfile::Evaluator do
     end
 
     describe 'selection of the Guardfile data source' do
-      before { Guard::Guardfile::Evaluator.any_instance.stub(:_instance_eval_guardfile) }
+      before do
+        allow_any_instance_of(Guard::Guardfile::Evaluator).to receive(:_instance_eval_guardfile)
+      end
       disable_user_config
 
       context 'with no option' do
@@ -148,7 +150,7 @@ describe Guard::Guardfile::Evaluator do
 
         context 'home Guardfile'  do
           before do
-            File.stub(:exist?).with(local_guardfile) { false }
+            allow(File).to receive(:exist?).with(local_guardfile) { false }
             fake_guardfile(home_guardfile, valid_guardfile_string)
           end
 
@@ -276,8 +278,8 @@ describe Guard::Guardfile::Evaluator do
 
   describe '.reevaluate_guardfile' do
     before do
-      guardfile_evaluator.stub(:_instance_eval_guardfile)
-      ::Guard.runner.stub(:run)
+      allow(guardfile_evaluator).to receive(:_instance_eval_guardfile)
+      allow(::Guard.runner).to receive(:run)
     end
     let(:growl) { { name: :growl, options: {} } }
 
@@ -325,7 +327,7 @@ describe Guard::Guardfile::Evaluator do
 
     describe 'after reevaluation' do
       context 'with notifications enabled' do
-        before { ::Guard::Notifier.stub(:enabled?).and_return(true) }
+        before { allow(::Guard::Notifier).to receive(:enabled?).and_return(true) }
 
         it 'enables the notifications again' do
           expect(::Guard::Notifier).to receive(:turn_on)
@@ -335,7 +337,7 @@ describe Guard::Guardfile::Evaluator do
       end
 
       context 'with notifications disabled' do
-        before { ::Guard::Notifier.stub(:enabled?).and_return(false) }
+        before { allow(::Guard::Notifier).to receive(:enabled?).and_return(false) }
 
         it 'does not enable the notifications again' do
           expect(::Guard::Notifier).to_not receive(:turn_on)
@@ -346,8 +348,8 @@ describe Guard::Guardfile::Evaluator do
 
       context 'with Guards afterwards' do
         before do
-          ::Guard.stub(:plugins).and_return([double('Guard::Dummy')])
-          ::Guard.runner.stub(:run)
+          allow(::Guard).to receive(:plugins).and_return([double('Guard::Dummy')])
+          allow(::Guard.runner).to receive(:run)
         end
 
         it 'shows a success message' do
@@ -383,25 +385,25 @@ describe Guard::Guardfile::Evaluator do
 
   describe '.guardfile_include?' do
     it 'detects a guard specified by a string with double quotes' do
-      guardfile_evaluator.stub(_guardfile_contents_without_user_config: 'guard "test" {watch("c")}')
+      allow(guardfile_evaluator).to receive(:_guardfile_contents_without_user_config).and_return('guard "test" {watch("c")}')
 
       expect(guardfile_evaluator.guardfile_include?('test')).to be_truthy
     end
 
     it 'detects a guard specified by a string with single quote' do
-      guardfile_evaluator.stub(_guardfile_contents_without_user_config: 'guard \'test\' {watch("c")}')
+      allow(guardfile_evaluator).to receive(:_guardfile_contents_without_user_config).and_return('guard \'test\' {watch("c")}')
 
       expect(guardfile_evaluator.guardfile_include?('test')).to be_truthy
     end
 
     it 'detects a guard specified by a symbol' do
-      guardfile_evaluator.stub(_guardfile_contents_without_user_config: 'guard :test {watch("c")}')
+      allow(guardfile_evaluator).to receive(:_guardfile_contents_without_user_config).and_return('guard :test {watch("c")}')
 
       expect(guardfile_evaluator.guardfile_include?('test')).to be_truthy
     end
 
     it 'detects a guard wrapped in parentheses' do
-      guardfile_evaluator.stub(_guardfile_contents_without_user_config: 'guard(:test) {watch("c")}')
+      allow(guardfile_evaluator).to receive(:_guardfile_contents_without_user_config).and_return('guard(:test) {watch("c")}')
 
       expect(guardfile_evaluator.guardfile_include?('test')).to be_truthy
     end
@@ -410,8 +412,8 @@ describe Guard::Guardfile::Evaluator do
   private
 
   def fake_guardfile(name, contents)
-    File.stub(:exist?).with(name) { true }
-    File.stub(:read).with(name)   { contents }
+    allow(File).to receive(:exist?).with(name) { true }
+    allow(File).to receive(:read).with(name)   { contents }
   end
 
   def valid_guardfile_string

--- a/spec/lib/guard/guardfile/generator_spec.rb
+++ b/spec/lib/guard/guardfile/generator_spec.rb
@@ -10,7 +10,7 @@ describe Guard::Guardfile::Generator do
   end
 
   describe '#create_guardfile' do
-    before { Dir.stub(:pwd).and_return "/home/user" }
+    before { allow(Dir).to receive(:pwd).and_return "/home/user" }
 
     context "with an existing Guardfile" do
       before { expect(File).to receive(:exist?) { true } }
@@ -82,7 +82,7 @@ describe Guard::Guardfile::Generator do
     context "when the passed guard can't be found" do
       before do
         expect(::Guard::PluginUtil).to receive(:new) { plugin_util }
-        plugin_util.stub(:plugin_class) { nil }
+        allow(plugin_util).to receive(:plugin_class) { nil }
         expect(File).to receive(:exist?).and_return false
       end
 

--- a/spec/lib/guard/guardfile_spec.rb
+++ b/spec/lib/guard/guardfile_spec.rb
@@ -22,7 +22,7 @@ describe Guard::Guardfile do
   describe '.initialize_template' do
     before do
       expect(described_class::Generator).to receive(:new) { guardfile_generator }
-      guardfile_generator.stub(:initialize_template)
+      allow(guardfile_generator).to receive(:initialize_template)
     end
 
     it 'displays a deprecation warning to the user' do
@@ -41,7 +41,7 @@ describe Guard::Guardfile do
   describe '.initialize_all_templates' do
     before do
       expect(described_class::Generator).to receive(:new) { guardfile_generator }
-      guardfile_generator.stub(:initialize_all_templates)
+      allow(guardfile_generator).to receive(:initialize_all_templates)
     end
 
     it 'displays a deprecation warning to the user' do

--- a/spec/lib/guard/interactor_spec.rb
+++ b/spec/lib/guard/interactor_spec.rb
@@ -116,10 +116,10 @@ describe Guard::Interactor do
 
     describe '#_prompt(ending_char)' do
       before do
-        ::Guard.stub(:scope).and_return({})
-        ::Guard.scope.stub(:[]).with(:plugins).and_return([])
-        ::Guard.scope.stub(:[]).with(:groups).and_return([])
-        ::Guard.stub(:listener).and_return(double('listener', paused?: false))
+        allow(::Guard).to receive(:scope).and_return({})
+        allow(::Guard.scope).to receive(:[]).with(:plugins).and_return([])
+        allow(::Guard.scope).to receive(:[]).with(:groups).and_return([])
+        allow(::Guard).to receive(:listener).and_return(double('listener', paused?: false))
         expect(::Guard.interactor).to receive(:_clip_name).and_return('main')
       end
       let(:pry) { double(input_array: []) }
@@ -131,7 +131,7 @@ describe Guard::Interactor do
       end
 
       context 'Guard is paused' do
-        before { ::Guard.stub(:listener).and_return(double('listener', paused?: true)) }
+        before { allow(::Guard).to receive(:listener).and_return(double('listener', paused?: true)) }
 
         it 'displays "pause"' do
           expect(::Guard.interactor.send(:_prompt, '>').call(double, 0, pry)).to eq '[0] pause(main)> '
@@ -139,7 +139,7 @@ describe Guard::Interactor do
       end
 
       context 'with a groups scope' do
-        before { ::Guard.scope.stub(:[]).with(:groups).and_return([double(title: 'Backend'), double(title: 'Frontend')]) }
+        before { allow(::Guard.scope).to receive(:[]).with(:groups).and_return([double(title: 'Backend'), double(title: 'Frontend')]) }
 
         it 'displays the group scope title in the prompt' do
           expect(::Guard.interactor.send(:_prompt, '>').call(double, 0, pry)).to eq '[0] Backend,Frontend guard(main)> '
@@ -147,7 +147,7 @@ describe Guard::Interactor do
       end
 
       context 'with a plugins scope' do
-        before { ::Guard.scope.stub(:[]).with(:plugins).and_return([double(title: 'RSpec'), double(title: 'Ronn')]) }
+        before { allow(::Guard.scope).to receive(:[]).with(:plugins).and_return([double(title: 'RSpec'), double(title: 'Ronn')]) }
 
         it 'displays the group scope title in the prompt' do
           expect(::Guard.interactor.send(:_prompt, '>').call(double, 0, pry)).to eq '[0] RSpec,Ronn guard(main)> '

--- a/spec/lib/guard/notifier_spec.rb
+++ b/spec/lib/guard/notifier_spec.rb
@@ -80,7 +80,7 @@ describe Guard::Notifier do
         end
 
         it 'does enable the notifications when a library is available' do
-          Guard::Notifier.stub(:add_notifier) do
+          allow(Guard::Notifier).to receive(:add_notifier) do
             Guard::Notifier.notifiers = [gntp]
             true
           end
@@ -89,7 +89,7 @@ describe Guard::Notifier do
         end
 
         it 'does turn on the notification module for libraries that are available' do
-          Guard::Notifier.stub(:add_notifier) do
+          allow(Guard::Notifier).to receive(:add_notifier) do
             Guard::Notifier.notifiers = [{ name: :tmux, options: {} }]
             true
           end
@@ -99,7 +99,7 @@ describe Guard::Notifier do
         end
 
         it 'does not enable the notifications when no library is available' do
-          Guard::Notifier.stub(:add_notifier).and_return false
+          allow(Guard::Notifier).to receive(:add_notifier).and_return false
           Guard::Notifier.turn_on
           expect(Guard::Notifier).not_to be_enabled
         end
@@ -141,7 +141,7 @@ describe Guard::Notifier do
   end
 
   describe 'toggle_notification' do
-    before { ::Guard::UI.stub(:info) }
+    before { allow(::Guard::UI).to receive(:info) }
 
     it 'disables the notifications when enabled' do
       ENV['GUARD_NOTIFY'] = 'true'
@@ -220,7 +220,7 @@ describe Guard::Notifier do
 
     context 'when notifications are enabled' do
       before do
-        Guard::Notifier.stub(:enabled?).and_return true
+        allow(Guard::Notifier).to receive(:enabled?).and_return true
 
         expect(Guard::Notifier::GNTP).to receive(:new).with(color: true).and_return(gntp_object)
         expect(Guard::Notifier::Growl).to receive(:new).with({}).and_return(growl_object)
@@ -237,7 +237,7 @@ describe Guard::Notifier do
 
     context 'when notifications are disabled' do
       before do
-        Guard::Notifier.stub(:enabled?).and_return false
+        allow(Guard::Notifier).to receive(:enabled?).and_return false
       end
 
       it 'does not send any notifications to a notifier' do

--- a/spec/lib/guard/notifiers/base_spec.rb
+++ b/spec/lib/guard/notifiers/base_spec.rb
@@ -10,7 +10,7 @@ describe Guard::Notifier::Base do
     end
   end
 
-  before { subject.stub(:require) }
+  before { allow(subject).to receive(:require) }
 
   describe '.name' do
     it 'un-modulizes the class, replaces "xY" with "x_Y" and downcase' do

--- a/spec/lib/guard/notifiers/emacs_spec.rb
+++ b/spec/lib/guard/notifiers/emacs_spec.rb
@@ -16,7 +16,7 @@ describe Guard::Notifier::Emacs do
       let(:notifier) { described_class.new(success: 'Green', silent: true) }
 
       it 'uses these options by default' do
-        notifier.should_receive(:_run_cmd) do |*command|
+        expect(notifier).to receive(:_run_cmd) do |*command|
           expect(command).to include("emacsclient")
           expect(command).to include(%{(set-face-attribute 'mode-line nil :background "Green" :foreground "White")})
         end
@@ -25,7 +25,7 @@ describe Guard::Notifier::Emacs do
       end
 
       it 'overwrites object options with passed options' do
-        notifier.should_receive(:_run_cmd) do |*command|
+        expect(notifier).to receive(:_run_cmd) do |*command|
           expect(command).to include("emacsclient")
           expect(command).to include(%{(set-face-attribute 'mode-line nil :background "LightGreen" :foreground "White")})
         end
@@ -36,7 +36,7 @@ describe Guard::Notifier::Emacs do
 
     context 'when no color options are specified' do
       it 'should set modeline color to the default color using emacsclient' do
-        notifier.should_receive(:_run_cmd) do |*command|
+        expect(notifier).to receive(:_run_cmd) do |*command|
           expect(command).to include("emacsclient")
           expect(command).to include(%{(set-face-attribute 'mode-line nil :background "ForestGreen" :foreground "White")})
         end
@@ -47,7 +47,7 @@ describe Guard::Notifier::Emacs do
 
     context 'when a color option is specified for "success" notifications' do
       it 'should set modeline color to the specified color using emacsclient' do
-        notifier.should_receive(:_run_cmd) do |*command|
+        expect(notifier).to receive(:_run_cmd) do |*command|
           expect(command).to include("emacsclient")
           expect(command).to include(%{(set-face-attribute 'mode-line nil :background "Orange" :foreground "White")})
         end
@@ -58,7 +58,7 @@ describe Guard::Notifier::Emacs do
 
     context 'when a color option is specified for "pending" notifications' do
       it 'should set modeline color to the specified color using emacsclient' do
-        notifier.should_receive(:_run_cmd) do |*command|
+        expect(notifier).to receive(:_run_cmd) do |*command|
           expect(command).to include("emacsclient")
           expect(command).to include(%{(set-face-attribute 'mode-line nil :background "Yellow" :foreground "White")})
         end

--- a/spec/lib/guard/notifiers/gntp_spec.rb
+++ b/spec/lib/guard/notifiers/gntp_spec.rb
@@ -5,7 +5,7 @@ describe Guard::Notifier::GNTP do
   let(:gntp) { double('GNTP').as_null_object }
 
   before do
-    described_class.stub(:require_gem_safely).and_return(true)
+    allow(described_class).to receive(:require_gem_safely).and_return(true)
     stub_const 'GNTP', gntp
   end
 
@@ -19,7 +19,7 @@ describe Guard::Notifier::GNTP do
 
   describe '.available?' do
     context 'host is not supported' do
-      before { RbConfig::CONFIG.stub(:[]).with('host_os').and_return('foobar') }
+      before { allow(RbConfig::CONFIG).to receive(:[]).with('host_os').and_return('foobar') }
 
       it 'do not require ruby_gntp' do
         expect(described_class).to_not receive(:require_gem_safely)
@@ -29,7 +29,7 @@ describe Guard::Notifier::GNTP do
     end
 
     context 'host is supported' do
-      before { RbConfig::CONFIG.stub(:[]).with('host_os').and_return('darwin') }
+      before { allow(RbConfig::CONFIG).to receive(:[]).with('host_os').and_return('darwin') }
 
       it 'requires ruby_gntp' do
         expect(described_class).to receive(:require_gem_safely) { true }
@@ -41,8 +41,8 @@ describe Guard::Notifier::GNTP do
 
   describe '#client' do
     before do
-      ::GNTP.stub(:new).and_return(gntp)
-      gntp.stub(:register)
+      allow(::GNTP).to receive(:new).and_return(gntp)
+      allow(gntp).to receive(:register)
     end
 
     it 'creates a new GNTP client and memoize it' do
@@ -62,7 +62,7 @@ describe Guard::Notifier::GNTP do
   end
 
   describe '#notify' do
-    before { notifier.stub(:_client).and_return(gntp) }
+    before { allow(notifier).to receive(:_client).and_return(gntp) }
 
     context 'with options passed at initialization' do
       let(:notifier) { described_class.new(title: 'Hello', silent: true) }

--- a/spec/lib/guard/notifiers/growl_notify_spec.rb
+++ b/spec/lib/guard/notifiers/growl_notify_spec.rb
@@ -4,7 +4,7 @@ describe Guard::Notifier::GrowlNotify do
   let(:notifier) { described_class.new }
 
   before do
-    described_class.stub(:require_gem_safely).and_return(true)
+    allow(described_class).to receive(:require_gem_safely).and_return(true)
     stub_const 'GrowlNotify', double
   end
 
@@ -14,7 +14,7 @@ describe Guard::Notifier::GrowlNotify do
 
   describe '.available?' do
     context 'host is not supported' do
-      before { RbConfig::CONFIG.stub(:[]).with('host_os').and_return('mswin') }
+      before { allow(RbConfig::CONFIG).to receive(:[]).with('host_os').and_return('mswin') }
 
       it 'do not require growl_notify' do
         expect(described_class).to_not receive(:require_gem_safely)
@@ -24,7 +24,7 @@ describe Guard::Notifier::GrowlNotify do
     end
 
     context 'host is supported' do
-      before { RbConfig::CONFIG.stub(:[]).with('host_os').and_return('darwin') }
+      before { allow(RbConfig::CONFIG).to receive(:[]).with('host_os').and_return('darwin') }
 
       it 'requires growl_notify' do
         expect(described_class).to receive(:require_gem_safely) { true }

--- a/spec/lib/guard/notifiers/growl_spec.rb
+++ b/spec/lib/guard/notifiers/growl_spec.rb
@@ -5,7 +5,7 @@ describe Guard::Notifier::Growl do
   let(:growl) { double('Growl', installed?: true) }
 
   before do
-    described_class.stub(:require_gem_safely).and_return(true)
+    allow(described_class).to receive(:require_gem_safely).and_return(true)
     stub_const 'Growl', growl
   end
 
@@ -15,7 +15,7 @@ describe Guard::Notifier::Growl do
 
   describe '.available?' do
     context 'host is not supported' do
-      before { RbConfig::CONFIG.stub(:[]).with('host_os').and_return('mswin') }
+      before { allow(RbConfig::CONFIG).to receive(:[]).with('host_os').and_return('mswin') }
 
       it 'do not require growl' do
         expect(described_class).to_not receive(:require_gem_safely)
@@ -25,7 +25,7 @@ describe Guard::Notifier::Growl do
     end
 
     context 'host is supported' do
-      before { RbConfig::CONFIG.stub(:[]).with('host_os').and_return('darwin') }
+      before { allow(RbConfig::CONFIG).to receive(:[]).with('host_os').and_return('darwin') }
 
       it 'requires growl' do
         expect(described_class).to receive(:require_gem_safely) { true }

--- a/spec/lib/guard/notifiers/libnotify_spec.rb
+++ b/spec/lib/guard/notifiers/libnotify_spec.rb
@@ -4,7 +4,7 @@ describe Guard::Notifier::Libnotify do
   let(:notifier) { described_class.new }
 
   before do
-    described_class.stub(:require_gem_safely).and_return(true)
+    allow(described_class).to receive(:require_gem_safely).and_return(true)
     stub_const 'Libnotify', double
   end
 
@@ -14,7 +14,7 @@ describe Guard::Notifier::Libnotify do
 
   describe '.available?' do
     context 'host is not supported' do
-      before { RbConfig::CONFIG.stub(:[]).with('host_os').and_return('mswin') }
+      before { allow(RbConfig::CONFIG).to receive(:[]).with('host_os').and_return('mswin') }
 
       it 'do not require libnotify' do
         expect(described_class).to_not receive(:require_gem_safely)
@@ -24,7 +24,7 @@ describe Guard::Notifier::Libnotify do
     end
 
     context 'host is supported' do
-      before { RbConfig::CONFIG.stub(:[]).with('host_os').and_return('linux') }
+      before { allow(RbConfig::CONFIG).to receive(:[]).with('host_os').and_return('linux') }
 
       it 'requires libnotify' do
         expect(described_class).to receive(:require_gem_safely) { true }

--- a/spec/lib/guard/notifiers/notifysend_spec.rb
+++ b/spec/lib/guard/notifiers/notifysend_spec.rb
@@ -13,7 +13,7 @@ describe Guard::Notifier::NotifySend do
 
   describe '.available?' do
     context 'host is not supported' do
-      before { RbConfig::CONFIG.stub(:[]).with('host_os').and_return('mswin') }
+      before { allow(RbConfig::CONFIG).to receive(:[]).with('host_os').and_return('mswin') }
 
       it 'do not check if the binary is available' do
         expect(described_class).to_not receive(:_notifysend_binary_available?)
@@ -23,7 +23,7 @@ describe Guard::Notifier::NotifySend do
     end
 
     context 'host is supported' do
-      before { RbConfig::CONFIG.stub(:[]).with('host_os').and_return('linux') }
+      before { allow(RbConfig::CONFIG).to receive(:[]).with('host_os').and_return('linux') }
 
       it 'checks if the binary is available' do
         expect(described_class).to receive(:_notifysend_binary_available?) { true }
@@ -38,7 +38,7 @@ describe Guard::Notifier::NotifySend do
       let(:notifier) { described_class.new(image: '/tmp/hello.png', silent: true) }
 
       it 'uses these options by default' do
-        notifier.should_receive(:system) do |command, *arguments|
+        expect(notifier).to receive(:system) do |command, *arguments|
           expect(command).to eql 'notify-send'
           expect(arguments).to include '-i', '/tmp/hello.png'
           expect(arguments).to include '-u', 'low'
@@ -50,7 +50,7 @@ describe Guard::Notifier::NotifySend do
       end
 
       it 'overwrites object options with passed options' do
-        notifier.should_receive(:system) do |command, *arguments|
+        expect(notifier).to receive(:system) do |command, *arguments|
           expect(command).to eql 'notify-send'
           expect(arguments).to include '-i', '/tmp/welcome.png'
           expect(arguments).to include '-u', 'low'
@@ -62,7 +62,7 @@ describe Guard::Notifier::NotifySend do
       end
 
       it 'uses the title provided in the options' do
-        notifier.should_receive(:system) do |command, *arguments|
+        expect(notifier).to receive(:system) do |command, *arguments|
           expect(command).to eql 'notify-send'
           expect(arguments).to include 'Welcome to Guard'
           expect(arguments).to include 'test title'
@@ -73,7 +73,7 @@ describe Guard::Notifier::NotifySend do
 
     context 'without additional options' do
       it 'shows the notification with the default options' do
-        notifier.should_receive(:system) do |command, *arguments|
+        expect(notifier).to receive(:system) do |command, *arguments|
           expect(command).to eql 'notify-send'
           expect(arguments).to include '-i', '/tmp/welcome.png'
           expect(arguments).to include '-u', 'low'
@@ -87,7 +87,7 @@ describe Guard::Notifier::NotifySend do
 
     context 'with additional options' do
       it 'can override the default options' do
-        notifier.should_receive(:system) do |command, *arguments|
+        expect(notifier).to receive(:system) do |command, *arguments|
           expect(command).to eql 'notify-send'
           expect(arguments).to include '-i', '/tmp/wait.png'
           expect(arguments).to include '-u', 'critical'

--- a/spec/lib/guard/notifiers/rb_notifu_spec.rb
+++ b/spec/lib/guard/notifiers/rb_notifu_spec.rb
@@ -4,7 +4,7 @@ describe Guard::Notifier::Notifu do
   let(:notifier) { described_class.new }
 
   before do
-    described_class.stub(:require_gem_safely).and_return(true)
+    allow(described_class).to receive(:require_gem_safely).and_return(true)
     stub_const 'Notifu', double
   end
 
@@ -18,7 +18,7 @@ describe Guard::Notifier::Notifu do
 
   describe '.available?' do
     context 'host is not supported' do
-      before { RbConfig::CONFIG.stub(:[]).with('host_os').and_return('darwin') }
+      before { allow(RbConfig::CONFIG).to receive(:[]).with('host_os').and_return('darwin') }
 
       it 'do not require rb-notifu' do
         expect(described_class).to_not receive(:require_gem_safely)
@@ -28,7 +28,7 @@ describe Guard::Notifier::Notifu do
     end
 
     context 'host is supported' do
-      before { RbConfig::CONFIG.stub(:[]).with('host_os').and_return('mswin') }
+      before { allow(RbConfig::CONFIG).to receive(:[]).with('host_os').and_return('mswin') }
 
       it 'requires rb-notifu' do
         expect(described_class).to receive(:require_gem_safely) { true }

--- a/spec/lib/guard/notifiers/terminal_notifier_spec.rb
+++ b/spec/lib/guard/notifiers/terminal_notifier_spec.rb
@@ -4,7 +4,7 @@ describe Guard::Notifier::TerminalNotifier do
   let(:notifier) { described_class.new }
 
   before do
-    described_class.stub(:require_gem_safely).and_return(true)
+    allow(described_class).to receive(:require_gem_safely).and_return(true)
     stub_const 'TerminalNotifier::Guard', double(available?: true)
   end
 
@@ -18,7 +18,7 @@ describe Guard::Notifier::TerminalNotifier do
 
   describe '.available?' do
     context 'host is not supported' do
-      before { RbConfig::CONFIG.stub(:[]).with('host_os').and_return('mswin') }
+      before { allow(RbConfig::CONFIG).to receive(:[]).with('host_os').and_return('mswin') }
 
       it 'do not require terminal-notifier-guard' do
         expect(described_class).to_not receive(:require_gem_safely)
@@ -28,7 +28,7 @@ describe Guard::Notifier::TerminalNotifier do
     end
 
     context 'host is supported' do
-      before { RbConfig::CONFIG.stub(:[]).with('host_os').and_return('darwin') }
+      before { allow(RbConfig::CONFIG).to receive(:[]).with('host_os').and_return('darwin') }
 
       it 'requires terminal-notifier-guard' do
         expect(described_class).to receive(:require_gem_safely) { true }

--- a/spec/lib/guard/notifiers/tmux_spec.rb
+++ b/spec/lib/guard/notifiers/tmux_spec.rb
@@ -97,28 +97,28 @@ describe Guard::Notifier::Tmux do
     end
 
     it 'calls display_message if the display_message flag is set' do
-      notifier.stub system: true
+      allow(notifier).to receive(:system).and_return(true)
       expect(notifier).to receive(:display_message).with('notify', 'Guard', 'any message', display_message: true)
 
       notifier.notify('any message', type: :notify, display_message: true)
     end
 
     it 'does not call display_message if the display_message flag is not set' do
-      notifier.stub system: true
+      allow(notifier).to receive(:system).and_return(true)
       expect(notifier).to receive(:display_message).never
 
       notifier.notify('any message')
     end
 
     it 'calls display_title if the display_title flag is set' do
-      notifier.stub system: true
+      allow(notifier).to receive(:system).and_return(true)
       expect(notifier).to receive(:display_title).with('notify', 'Guard', 'any message', display_title: true)
 
       notifier.notify('any message', type: :notify, display_title: true)
     end
 
     it 'does not call display_title if the display_title flag is not set' do
-      notifier.stub system: true
+      allow(notifier).to receive(:system).and_return(true)
       expect(notifier).to receive(:display_title).never
 
       notifier.notify('any message')
@@ -134,12 +134,12 @@ describe Guard::Notifier::Tmux do
 
   describe '#display_title' do
     before do
-      notifier.stub system: true
+      allow(notifier).to receive(:system).and_return(true)
     end
 
     context 'for tmux >= 1.7' do
       before do
-        notifier.stub _tmux_version: 1.7
+        allow(notifier).to receive(:_tmux_version).and_return(1.7)
       end
 
       it 'displays the title' do
@@ -181,7 +181,7 @@ describe Guard::Notifier::Tmux do
 
     context 'for tmux <= 1.6' do
       before do
-        notifier.stub _tmux_version: 1.6
+        expect(notifier).to receive(:_tmux_version).and_return(1.6)
       end
 
       it 'does not add the quiet flag' do
@@ -194,7 +194,7 @@ describe Guard::Notifier::Tmux do
 
   describe '#display_message' do
     before do
-      notifier.stub system: true
+      allow(notifier).to receive(:system).and_return(true)
     end
 
     it 'sets the display-time' do
@@ -277,9 +277,9 @@ describe Guard::Notifier::Tmux do
 
   describe '#turn_on' do
     before do
-      described_class.stub(:`).and_return("option1 setting1\noption2 setting2\n")
-      described_class.stub(:_clients).and_return(['tty'])
-      described_class.stub system: true
+      allow(described_class).to receive(:`).and_return("option1 setting1\noption2 setting2\n")
+      allow(described_class).to receive(:_clients).and_return(['tty'])
+      allow(described_class).to receive(:system).and_return(true)
     end
 
     context 'when off' do
@@ -321,9 +321,9 @@ describe Guard::Notifier::Tmux do
 
   describe '#turn_off' do
     before do
-      described_class.stub(:`).and_return("option1 setting1\noption2 setting2\n")
-      described_class.stub(:_clients).and_return(['tty'])
-      described_class.stub system: true
+      allow(described_class).to receive(:`).and_return("option1 setting1\noption2 setting2\n")
+      allow(described_class).to receive(:_clients).and_return(['tty'])
+      allow(described_class).to receive(:system).and_return(true)
     end
 
     context 'when on' do

--- a/spec/lib/guard/plugin/base_spec.rb
+++ b/spec/lib/guard/plugin/base_spec.rb
@@ -20,7 +20,7 @@ describe Guard::Plugin::Base do
 
   describe '.template' do
     before do
-      File.stub(:read)
+      allow(File).to receive(:read)
     end
 
     it 'reads the default template' do

--- a/spec/lib/guard/plugin_util_spec.rb
+++ b/spec/lib/guard/plugin_util_spec.rb
@@ -39,8 +39,8 @@ describe Guard::PluginUtil do
           double(name: 'gem1', full_gem_path: '/gem1'),
           double(name: 'gem2', full_gem_path: '/gem2'),
         ]
-        File.stub(:exists?).with('/gem1/lib/guard/gem1.rb') { false }
-        File.stub(:exists?).with('/gem2/lib/guard/gem2.rb') { true }
+        allow(File).to receive(:exists?).with('/gem1/lib/guard/gem1.rb').and_return(false)
+        allow(File).to receive(:exists?).with('/gem2/lib/guard/gem2.rb').and_return(true)
         expect(Gem::Specification).to receive(:find_all) { gems }
       end
 
@@ -68,7 +68,9 @@ describe Guard::PluginUtil do
     let(:plugin_util) { described_class.new('rspec') }
 
     before do
-      described_class.any_instance.stub(:plugin_class).and_return(guard_rspec_class)
+      allow_any_instance_of(described_class)
+        .to receive(:plugin_class)
+        .and_return(guard_rspec_class)
     end
 
     context 'with a plugin inheriting from Guard::Guard (deprecated)' do
@@ -216,12 +218,12 @@ describe Guard::PluginUtil do
 
   describe '#add_to_guardfile' do
     before do
-      ::Guard.stub(:evaluator) { guardfile_evaluator }
+      allow(::Guard).to receive(:evaluator) { guardfile_evaluator }
     end
 
     context 'when the Guard is already in the Guardfile' do
       before do
-        guardfile_evaluator.stub(:guardfile_include?).and_return(true)
+        allow(guardfile_evaluator).to receive(:guardfile_include?).and_return(true)
       end
 
       it 'shows an info message' do
@@ -235,9 +237,9 @@ describe Guard::PluginUtil do
       let(:plugin_util) { described_class.new('myguard') }
       before do
         stub_const 'Guard::Myguard', Class.new(Guard::Plugin)
-        plugin_util.stub(:plugin_class) { Guard::Myguard }
+        allow(plugin_util).to receive(:plugin_class) { Guard::Myguard }
         expect(plugin_util).to receive(:plugin_location) { '/Users/me/projects/guard-myguard' }
-        guardfile_evaluator.stub(:guardfile_include?).and_return(false)
+        allow(guardfile_evaluator).to receive(:guardfile_include?).and_return(false)
       end
 
       it 'appends the template to the Guardfile' do

--- a/spec/lib/guard/runner_spec.rb
+++ b/spec/lib/guard/runner_spec.rb
@@ -15,12 +15,12 @@ describe Guard::Runner do
     @bar_guard      = guard.add_plugin(:bar, { group: :frontend })
     @baz_guard      = guard.add_plugin(:baz, { group: :frontend })
 
-    @foo_guard.stub(:my_task)
-    @bar_guard.stub(:my_task)
-    @baz_guard.stub(:my_task)
+    allow(@foo_guard).to receive(:my_task)
+    allow(@bar_guard).to receive(:my_task)
+    allow(@baz_guard).to receive(:my_task)
 
-    @foo_guard.stub(:my_hard_task)
-    @bar_guard.stub(:my_hard_task)
+    allow(@foo_guard).to receive(:my_hard_task)
+    allow(@bar_guard).to receive(:my_hard_task)
   end
 
   describe '#run' do
@@ -37,7 +37,7 @@ describe Guard::Runner do
     end
 
     context 'with a failing task' do
-      before { subject.stub(:run_supervised_task) { throw :task_has_failed } }
+      before { allow(subject).to receive(:run_supervised_task) { throw :task_has_failed } }
 
       it 'catches the thrown symbol' do
         expect {
@@ -79,7 +79,7 @@ describe Guard::Runner do
         let(:scope) { { plugins: [:foo, :bar] } }
 
         it 'executes the supervised task on the specified plugins only' do
-          @bar_guard.stub(:my_task)
+          allow(@bar_guard).to receive(:my_task)
           expect(subject).to receive(:run_supervised_task).with(@foo_guard, :my_task)
           expect(subject).to receive(:run_supervised_task).with(@bar_guard, :my_task)
 
@@ -163,9 +163,9 @@ describe Guard::Runner do
     let(:watcher_module) { ::Guard::Watcher }
 
     before do
-      subject.stub(:_scoped_plugins).and_yield(@foo_guard)
-      subject.stub(:_clearable?) { false }
-      watcher_module.stub(:match_files) { [] }
+      allow(subject).to receive(:_scoped_plugins).and_yield(@foo_guard)
+      allow(subject).to receive(:_clearable?) { false }
+      allow(watcher_module).to receive(:match_files) { [] }
     end
 
     it "always calls UI.clearable" do
@@ -174,7 +174,7 @@ describe Guard::Runner do
     end
 
     context 'when clearable' do
-      before { subject.stub(:_clearable?) { true } }
+      before { allow(subject).to receive(:_clearable?) { true } }
 
       it "clear UI" do
         expect(Guard::UI).to receive(:clear)
@@ -285,7 +285,7 @@ describe Guard::Runner do
     context 'with a task that succeeds' do
       context 'without any arguments' do
         before do
-          @foo_guard.stub(:regular_without_arg) { true }
+          allow(@foo_guard).to receive(:regular_without_arg) { true }
         end
 
         it 'does not remove the Guard' do
@@ -312,7 +312,7 @@ describe Guard::Runner do
 
       context 'with arguments' do
         before do
-          @foo_guard.stub(:regular_with_arg).with('given_path') { "I'm a success" }
+          allow(@foo_guard).to receive(:regular_with_arg).with('given_path') { "I'm a success" }
         end
 
         it 'does not remove the Guard' do
@@ -334,7 +334,7 @@ describe Guard::Runner do
     end
 
     context 'with a task that throws :task_has_failed' do
-      before { @foo_guard.stub(:failing) { throw :task_has_failed } }
+      before { allow(@foo_guard).to receive(:failing) { throw :task_has_failed } }
 
       context 'for a guard in group that has the :halt_on_fail option set to true' do
         before { @backend_group.options[:halt_on_fail] = true }
@@ -358,7 +358,7 @@ describe Guard::Runner do
     end
 
     context 'with a task that raises an exception' do
-      before { @foo_guard.stub(:failing) { raise 'I break your system' } }
+      before { allow(@foo_guard).to receive(:failing) { raise 'I break your system' } }
 
       it 'removes the Guard' do
         expect {
@@ -388,7 +388,7 @@ describe Guard::Runner do
 
     context 'for a group with :halt_on_fail' do
       before do
-        guard_plugin.group.stub(:options).and_return({ halt_on_fail: true })
+        allow(guard_plugin.group).to receive(:options).and_return({ halt_on_fail: true })
       end
 
       it 'returns :no_catch' do
@@ -398,7 +398,7 @@ describe Guard::Runner do
 
     context 'for a group without :halt_on_fail' do
       before do
-        guard_plugin.group.stub(:options).and_return({ halt_on_fail: false })
+        allow(guard_plugin.group).to receive(:options).and_return({ halt_on_fail: false })
       end
 
       it 'returns :task_has_failed' do

--- a/spec/lib/guard/setuper_spec.rb
+++ b/spec/lib/guard/setuper_spec.rb
@@ -7,8 +7,8 @@ describe Guard::Setuper do
 
   before do
     Guard.clear_options
-    Guard::Interactor.stub(:fabricate)
-    Dir.stub(:chdir)
+    allow(Guard::Interactor).to receive(:fabricate)
+    allow(Dir).to receive(:chdir)
   end
 
   describe '.setup' do
@@ -125,7 +125,7 @@ describe Guard::Setuper do
       subject { ::Guard.setup(options) }
 
       before do
-        Guard.stub(:_debug_command_execution)
+        allow(Guard).to receive(:_debug_command_execution)
       end
 
       it "logs command execution if the debug option is true" do
@@ -181,7 +181,7 @@ describe Guard::Setuper do
 
   describe '.evaluate_guardfile' do
     it 'evaluates the Guardfile' do
-      Guard.stub(:evaluator) { guardfile_evaluator }
+      allow(Guard).to receive(:evaluator) { guardfile_evaluator }
       expect(guardfile_evaluator).to receive(:evaluate_guardfile)
 
       Guard.evaluate_guardfile
@@ -190,7 +190,7 @@ describe Guard::Setuper do
 
   describe '._setup_signal_traps', speed: 'slow' do
     before do
-      ::Guard.stub(:evaluate_guardfile)
+      allow(::Guard).to receive(:evaluate_guardfile)
       ::Guard.setup
     end
 
@@ -335,7 +335,7 @@ describe Guard::Setuper do
     before { Guard.instance_variable_set '@watchdirs', ['/home/user/test'] }
 
     context "with latency option" do
-      before { ::Guard.stub(:options).and_return(Guard::Options.new(latency: 1.5)) }
+      before { allow(::Guard).to receive(:options).and_return(Guard::Options.new(latency: 1.5)) }
 
       it "pass option to listener" do
         expect(Listen).to receive(:to).with(anything, { latency: 1.5 }) { listener }
@@ -345,7 +345,7 @@ describe Guard::Setuper do
     end
 
     context "with force_polling option" do
-      before { ::Guard.stub(:options).and_return(Guard::Options.new(force_polling: true)) }
+      before { allow(::Guard).to receive(:options).and_return(Guard::Options.new(force_polling: true)) }
 
       it "pass option to listener" do
         expect(Listen).to receive(:to).with(anything, { force_polling: true }) { listener }
@@ -357,7 +357,7 @@ describe Guard::Setuper do
 
   describe '._setup_notifier' do
     context "with the notify option enabled" do
-      before { ::Guard.stub(:options).and_return(Guard::Options.new(notify: true)) }
+      before { allow(::Guard).to receive(:options).and_return(Guard::Options.new(notify: true)) }
 
       context 'without the environment variable GUARD_NOTIFY set' do
         before { ENV["GUARD_NOTIFY"] = nil }
@@ -379,7 +379,7 @@ describe Guard::Setuper do
     end
 
     context "with the notify option disabled" do
-      before { ::Guard.stub(:options).and_return(Guard::Options.new(notify: false)) }
+      before { allow(::Guard).to receive(:options).and_return(Guard::Options.new(notify: false)) }
 
       context 'without the environment variable GUARD_NOTIFY set' do
         before { ENV["GUARD_NOTIFY"] = nil }
@@ -451,7 +451,7 @@ describe Guard::Setuper do
 
     before do
       # Unstub global stub
-      Guard.unstub(:_debug_command_execution)
+      allow(Guard).to receive(:_debug_command_execution).and_call_original
 
       @original_system  = Kernel.method(:system)
       @original_command = Kernel.method(:`)

--- a/spec/lib/guard/ui_spec.rb
+++ b/spec/lib/guard/ui_spec.rb
@@ -8,28 +8,28 @@ describe Guard::UI do
     # The spec helper stubs all UI classes, so other specs doesn't have
     # to explicit take care of it. We unstub and move the stubs one layer
     # down just for this spec.
-    Guard::UI.unstub(:info)
-    Guard::UI.unstub(:warning)
-    Guard::UI.unstub(:error)
-    Guard::UI.unstub(:deprecation)
-    Guard::UI.unstub(:debug)
+    allow(Guard::UI).to receive(:info).and_call_original
+    allow(Guard::UI).to receive(:warning).and_call_original
+    allow(Guard::UI).to receive(:error).and_call_original
+    allow(Guard::UI).to receive(:deprecation).and_call_original
+    allow(Guard::UI).to receive(:debug).and_call_original
 
-    Guard::UI.logger.stub(:info)
-    Guard::UI.logger.stub(:warn)
-    Guard::UI.logger.stub(:error)
-    Guard::UI.logger.stub(:deprecation)
-    Guard::UI.logger.stub(:debug)
+    allow(Guard::UI.logger).to receive(:info)
+    allow(Guard::UI.logger).to receive(:warn)
+    allow(Guard::UI.logger).to receive(:error)
+    allow(Guard::UI.logger).to receive(:deprecation)
+    allow(Guard::UI.logger).to receive(:debug)
 
-    $stderr.stub(:print)
-    described_class.stub(:system)
+    allow($stderr).to receive(:print)
+    allow(described_class).to receive(:system)
   end
 
   after do
-    ::Guard::UI.stub(:info)
-    ::Guard::UI.stub(:warning)
-    ::Guard::UI.stub(:error)
-    ::Guard::UI.stub(:debug)
-    ::Guard::UI.stub(:deprecation)
+    allow(::Guard::UI).to receive(:info)
+    allow(::Guard::UI).to receive(:warning)
+    allow(::Guard::UI).to receive(:error)
+    allow(::Guard::UI).to receive(:debug)
+    allow(::Guard::UI).to receive(:deprecation)
   end
 
   describe '.logger' do
@@ -273,14 +273,14 @@ describe Guard::UI do
       end
 
       it 'doesn not clear the output if already cleared' do
-        Guard::UI.stub(:system)
+        allow(Guard::UI).to receive(:system)
         Guard::UI.clear
         expect(Guard::UI).to_not receive(:system).with('clear;')
         Guard::UI.clear
       end
 
       it 'clears the outputs if forced' do
-        Guard::UI.stub(:system)
+        allow(Guard::UI).to receive(:system)
         Guard::UI.clear
         expect(Guard::UI).to receive(:system).with('clear;')
         Guard::UI.clear(force: true)

--- a/spec/lib/guard/watcher_spec.rb
+++ b/spec/lib/guard/watcher_spec.rb
@@ -17,12 +17,12 @@ describe Guard::Watcher do
 
       context "that is a regexp" do
         it "keeps the regex pattern unmodified" do
-          expect(described_class.new(/spec_helper\.rb/).pattern).to eq /spec_helper\.rb/
+          expect(described_class.new(/spec_helper\.rb/).pattern).to eq(/spec_helper\.rb/)
         end
       end
 
       context "that is a string looking like a regex (deprecated)" do
-        before(:each) { Guard::UI.stub(:info) }
+        before(:each) { allow(Guard::UI).to receive(:info) }
 
         it "converts the string automatically to a regex" do
           expect(described_class.new('^spec_helper.rb').pattern).to eq(/^spec_helper.rb/)
@@ -331,7 +331,7 @@ describe Guard::Watcher do
   end
 
   describe '.match_guardfile?' do
-    before { Guard.stub(:evaluator) { double(guardfile_path: File.expand_path('Guardfile')) } }
+    before { allow(Guard).to receive(:evaluator) { double(guardfile_path: File.expand_path('Guardfile')) } }
 
     context "with files that match the Guardfile" do
       specify { expect(described_class.match_guardfile?(['Guardfile', 'guard_rocks_spec.rb'])).to be_truthy }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@ RSpec.configure do |config|
   config.order = :random
   config.filter_run focus: ENV['CI'] != 'true'
   config.run_all_when_everything_filtered = true
+  config.raise_errors_for_deprecations!
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end


### PR DESCRIPTION
rspec-mock 3.0 has a new syntax for stubbing.  The old syntax raises
deprecation warning.  This change fixes it.

I did this while trying to troubleshoot issue #563
