### PR TITLE
rspec: Prevent user's .guard.rb from breaking tests.

### DIFF
--- a/spec/.gitignore
+++ b/spec/.gitignore
@@ -1,0 +1,1 @@
+/fake-home/

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,16 @@ RSpec.configure do |config|
     ::Guard.reset_plugins
   end
 
+  config.before(:suite) do
+    # Use a fake home directory so that user configurations,
+    # such as their ~/.guard.rb file, won't impact the
+    # tests.
+    fake_home = File.expand_path('../fake-home', __FILE__)
+    FileUtils.rmtree fake_home
+    FileUtils.mkdir  fake_home
+    ENV['HOME'] = fake_home
+  end
+
   config.before(:all) do
     @guard_notify ||= ENV['GUARD_NOTIFY']
     @guard_notifiers ||= ::Guard::Notifier.notifiers


### PR DESCRIPTION
This changes the HOME variable to point at a `spec/fake-home/` so that the
user's configurations won't impact the test runs.

Fixes #558
