### PR TITLE
Make minimum listen version 2.7

### DIFF
--- a/guard.gemspec
+++ b/guard.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   s.add_runtime_dependency 'thor',       '>= 0.18.1'
-  s.add_runtime_dependency 'listen',     '~> 2.6'
+  s.add_runtime_dependency 'listen',     '~> 2.7'
   s.add_runtime_dependency 'pry',        '>= 0.9.12'
   s.add_runtime_dependency 'lumberjack', '~> 1.0'
   s.add_runtime_dependency 'formatador', '>= 0.2.4'


### PR DESCRIPTION
Because versions of listen < 2.7 have a bug where the rails console and tests stop responding to SIGINT, and this is affecting all of our projects that use guard

See 
https://github.com/guard/listen/pull/195 &
https://github.com/guard/listen/pull/200
