### PR TITLE
Top level watches

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,8 +494,15 @@ You can also launch any arbitrary command in the supplied block:
 
 ```ruby
 guard :shell do
-  watch('.*') { `git status` }
+  watch(/.*/) { `git status` }
 end
+```
+
+You can also define `watch`es outside of a `guard` plugin. This is useful to perform arbitrary Ruby
+logic (i.e. something project-specific).
+
+```ruby
+watch(/.*/) { |m| puts "#{m[0]} changed." }
 ```
 
 ### group

--- a/lib/guard/dsl.rb
+++ b/lib/guard/dsl.rb
@@ -186,6 +186,9 @@ module Guard
     #     watch(%r{^app/controllers/(.+).rb}) { |m| 'spec/acceptance/#{m[1]}s_spec.rb' }
     #   end
     #
+    # @example Declare global watchers outside of a Guard
+    #   watch(%r{^(.+)$}) { |m| puts "#{m[1]} changed." }
+    #
     # @param [String, Regexp] pattern the pattern that Guard must watch for modification
     # @yield a block to be run when the pattern is matched
     # @yieldparam [MatchData] m matches of the pattern
@@ -195,7 +198,9 @@ module Guard
     # @see #guard
     #
     def watch(pattern, &action)
-      fail "watch must be called within a guard block" unless @plugin_options
+      # Allow watches in the global scope (to execute arbitrary commands) by
+      # building a generic Guard::Plugin.
+      return guard(:plugin) { watch(pattern, &action) } unless @plugin_options
 
       @plugin_options[:watchers] << ::Guard::Watcher.new(pattern, action)
     end

--- a/spec/lib/guard/dsl_spec.rb
+++ b/spec/lib/guard/dsl_spec.rb
@@ -232,12 +232,14 @@ describe Guard::Dsl do
       end')
     end
 
-    it 'should require a guard block' do
-      expect {
-        described_class.evaluate_guardfile(guardfile_contents: '
-          watch(\'a\') { \'b\' }
-          watch(\'c\')')
-      }.to raise_error(/guard block/i)
+    it 'should create an implicit no-op guard when outside a guard block' do
+      expect(::Guard).to receive(:add_plugin).with(:plugin, { watchers: [anything], callbacks: [], group: :default }) do |_, options|
+        expect(options[:watchers].size).to eq 1
+        expect(options[:watchers][0].pattern).to eq 'a'
+        expect(options[:watchers][0].action).to be_nil
+      end
+
+      described_class.evaluate_guardfile(guardfile_contents: 'watch(\'a\')')
     end
   end
 


### PR DESCRIPTION
Support for `watch` expressions outside of `guard` blocks.

My primary motivation is to reload the `Guardfile` when other files change, but this seems very useful for simple project-specific guards.

See http://stackoverflow.com/questions/22511991/reloading-guardfile-on-changes-to-files-other-than-the-guardfile for a bit of background.
