### PR TITLE
Fixes tmux notifier when display_on_all_clients is true

### DIFF
--- a/lib/guard/notifiers/tmux.rb
+++ b/lib/guard/notifiers/tmux.rb
@@ -251,7 +251,9 @@ module Guard
       end
 
       def self._clients
-        `#{ DEFAULTS[:client] } list-clients -F '\#{client_tty}'`.split(/\n/)
+        ttys = `#{ DEFAULTS[:client] } list-clients -F '\#{client_tty}'`.split(/\n/)
+        ttys.delete('(null)') #if user is running 'tmux -C' remove this client from list
+        ttys
       end
 
       def _clients

--- a/spec/lib/guard/notifiers/tmux_spec.rb
+++ b/spec/lib/guard/notifiers/tmux_spec.rb
@@ -375,4 +375,13 @@ describe Guard::Notifier::Tmux do
     end
   end
 
+  describe '#clients' do
+    it 'removes null terminal' do
+      allow(described_class).to receive(:`).and_return("/dev/ttys001\n/dev/ttys000\n(null)\n")
+      expect(described_class._clients).to include '/dev/ttys001'
+      expect(described_class._clients).to include '/dev/ttys000'
+      expect(described_class._clients).not_to include '(null)'
+    end
+  end
+
 end


### PR DESCRIPTION
line 254 no spaces '#{client_tty}' are important.
