### PR TITLE
correctly match notification type to urgency argument in notifysend, fixes #584

### DIFF
--- a/lib/guard/notifiers/notifysend.rb
+++ b/lib/guard/notifiers/notifysend.rb
@@ -87,7 +87,7 @@ module Guard
       # @return [String] the notify-send urgency
       #
       def _notifysend_urgency(type)
-        { 'failed' => 'normal', 'pending' => 'low' }.fetch(type, 'low')
+        { failed: 'normal', pending: 'low' }.fetch(type, 'low')
       end
 
       # Builds a shell command out of a command string and option hash.

--- a/spec/lib/guard/notifiers/notifysend_spec.rb
+++ b/spec/lib/guard/notifiers/notifysend_spec.rb
@@ -69,6 +69,24 @@ describe Guard::Notifier::NotifySend do
         end
         notifier.notify('Welcome to Guard', title: 'test title')
       end
+
+      it 'converts notification type failed to normal urgency' do
+        expect(notifier).to receive(:system) do |command, *arguments|
+          expect(command).to eql 'notify-send'
+          expect(arguments).to include '-u', 'normal'
+        end
+
+        notifier.notify('Welcome to Guard', type: :failed)
+      end
+
+      it 'converts notification type pending to low urgency' do
+        expect(notifier).to receive(:system) do |command, *arguments|
+          expect(command).to eql 'notify-send'
+          expect(arguments).to include '-u', 'low'
+        end
+
+        notifier.notify('Welcome to Guard', type: :pending)
+      end
     end
 
     context 'without additional options' do


### PR DESCRIPTION
The mapping of notification type <-> urgency argument was borked in the notifysend notifier and it would
always default to low urgency, no matter the notification type.
