### PR TITLE
Fix return type that changed at 6cec71c76d25094f696156ddfb3afe80377ff3f3

### DIFF
--- a/lib/guard.rb
+++ b/lib/guard.rb
@@ -46,7 +46,7 @@ module Guard
     #   Guard.plugins(name: 'rspec', group: 'backend')
     #
     # @param [String, Symbol, Regexp, Hash] filter the filter to apply to the plugins
-    # @return [Plugin, Array<Plugin>] the filtered plugin(s)
+    # @return [Array<Plugin>] the filtered plugin(s)
     #
     def plugins(filter = nil)
       @plugins ||= []


### PR DESCRIPTION
Return type of `plugins` method is `Array<Plugin>` only because had deleted `_smart_accessor_return_value` method at 6cec71c76d25094f696156ddfb3afe80377ff3f3.
