### PR TITLE
Stopping after the first matcher that returns a valid result

### DIFF
--- a/lib/guard/guard.rb
+++ b/lib/guard/guard.rb
@@ -29,6 +29,8 @@ module Guard
     # @option options [Symbol] group the group this Guard plugin belongs to
     # @option options [Boolean] any_return allow any object to be returned from
     #   a watcher
+    # @option options [Boolean] first_match stop after the first watcher that
+    #   returns a valid result
     #
     def initialize(watchers = [], options = {})
       UI.deprecation(Deprecator::GUARD_GUARD_DEPRECATION % title)

--- a/lib/guard/watcher.rb
+++ b/lib/guard/watcher.rb
@@ -52,8 +52,8 @@ module Guard
     def self.match_files(guard, files)
       return [] if files.empty?
 
-      guard.watchers.inject([]) do |paths, watcher|
-        files.each do |file|
+      files.inject([]) do |paths, file|
+        guard.watchers.each do |watcher|
           matches = watcher.match(file)
           next unless matches
 
@@ -63,10 +63,14 @@ module Guard
               paths << result
             elsif result.respond_to?(:empty?) && !result.empty?
               paths << Array(result)
+            else
+              next
             end
           else
             paths << matches[0]
           end
+
+          break if guard.options[:first_match]
         end
 
         guard.options[:any_return] ? paths : paths.flatten.map { |p| p.to_s }

--- a/spec/lib/guard/watcher_spec.rb
+++ b/spec/lib/guard/watcher_spec.rb
@@ -373,6 +373,38 @@ describe Guard::Watcher do
         described_class.match_files(@plugin, ['evil.rb'])
       end
     end
+
+    context 'for ambiguous watchers' do
+      before(:all) do
+        @plugin.watchers = [
+          described_class.new('awesome_helper.rb', lambda {}),
+          described_class.new(/.+some_helper.rb/, lambda { 'foo.rb' }),
+          described_class.new(/.+_helper.rb/, lambda { 'bar.rb' }),
+        ]
+      end
+
+      context 'when the :first_match option is turned off' do
+        before(:all) do
+          @plugin.options[:first_match] = false
+        end
+
+        it 'returns multiple files by combining the results of the watchers' do
+          expect(described_class.match_files(
+            @plugin, ['awesome_helper.rb'])).to eq(['foo.rb', 'bar.rb'])
+        end
+      end
+
+      context 'when the :first_match option is turned on' do
+        before(:all) do
+          @plugin.options[:first_match] = true
+        end
+
+        it 'returns only the files from the first watcher' do
+          expect(described_class.match_files(
+            @plugin, ['awesome_helper.rb'])).to eq(['foo.rb'])
+        end
+      end
+    end
   end
 
   describe '.match_files?' do


### PR DESCRIPTION
The proposed feature allows one to have the following definition of a guard:

``` ruby
guard :rspec, first_match: true do
  watch(%r{^lib/awesome_helper\.rb$}) { |m| 'foo.rb' }
  watch(%r{^lib/.+some_helper\.rb$}) { |m| 'bar.rb' }
  watch(%r{^lib/.+_helper\.rb$}) { |m| 'baz.rb' }
end
```

In this case, only the files returned by the first found matcher will be processed. For instance, `lib/handsome_helper.rb` will trigger only `bar.rb`.
