### PR TITLE
Typo fix and readme edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ $ bundle exec guard -P plugin_name another_plugin_name # shortcut
 
 #### `-d`/`--debug` option
 
-Guard can display debug information (useful for plugins
+Guard can display debug information (useful for plugin
 developers) with:
 
 ```bash


### PR DESCRIPTION
There were a few typos in this sentence: 'usefull' (should be useful) and reference to 'plugins developers' (should be 'plugin developers'). Fixed these typos and reworded the sentence for clarity.
