### PR TITLE
Don't warn if RUBYGEMS_GEMDEPS is set

### DIFF
--- a/lib/guard/cli.rb
+++ b/lib/guard/cli.rb
@@ -200,7 +200,7 @@ module Guard
     #
     def _verify_bundler_presence
       return unless File.exist?('Gemfile')
-      return if ENV['BUNDLE_GEMFILE']
+      return if ENV['BUNDLE_GEMFILE'] || ENV['RUBYGEMS_GEMDEPS']
 
       ::Guard::UI.info <<EOF
 


### PR DESCRIPTION
As you explain in the README, the **RUBYGEMS_GEMDEPS** also takes care of Gemfile-plumbing in newer versions of Rubygems. So here I skipped the warning if that env var is set.

Also, I should note that I poked around a little inside the `Gem` class to see if there was a way of asking it if gem dependencies have been activated either way rather than querying individually the existence of these env vars, but I didn't find anything. Perhaps someone else does in case I overlooked something, which is likely.

Unrelated aside: Guard's test env breaks when actually using **RUBYGEMS_GEMDEPS** in the shell, so I just ran the tests without it.
