### PR TITLE
Configure the scope according to the CLI options on re-evaluation of Guardfile

### DIFF
--- a/lib/guard/dsl.rb
+++ b/lib/guard/dsl.rb
@@ -364,8 +364,6 @@ module Guard
     # @param [Hash] scopes the scope for the groups and plugins
     #
     def scope(scope = {})
-      scope[:plugins] = Array(scope[:plugins] || scope[:plugin] || [])
-      scope[:groups] = Array(scope[:groups] || scope[:group] || [])
       ::Guard.setup_scope(scope)
     end
   end

--- a/lib/guard/guardfile/evaluator.rb
+++ b/lib/guard/guardfile/evaluator.rb
@@ -229,6 +229,7 @@ module Guard
           ::Guard::UI.info(msg)
           ::Guard::Notifier.notify(msg, title: 'Guard re-evaluate')
 
+          ::Guard.setup_scope
           ::Guard.runner.run(:start)
         end
       end

--- a/lib/guard/setuper.rb
+++ b/lib/guard/setuper.rb
@@ -92,10 +92,11 @@ module Guard
     # @see CLI#start
     # @see Dsl#scope
     #
-    def setup_scope(new_scope)
+    def setup_scope(scope = {})
+      scope = _prepare_scope(scope)
       { groups: :add_group, plugins: :plugin }.each do |type, meth|
-        next unless new_scope[type] && new_scope[type].any?
-        scope[type] = new_scope[type].map do |item|
+        next unless scope[type].any?
+        @scope[type] = scope[type].map do |item|
           ::Guard.send(meth, item)
         end
       end
@@ -311,8 +312,18 @@ module Guard
     def _load_guardfile
       _reset_all
       evaluate_guardfile
-      setup_scope(groups: options[:group], plugins: options[:plugin])
+      setup_scope
       _setup_notifier
+    end
+
+    def _prepare_scope(scope)
+      plugins = Array(options[:plugin])
+      plugins = Array(scope[:plugins] || scope[:plugin]) if plugins.empty?
+
+      groups = Array(options[:group])
+      groups = Array(scope[:groups] || scope[:group]) if groups.empty?
+
+      { plugins: plugins, groups: groups }
     end
   end
 end

--- a/spec/lib/guard/guardfile/evaluator_spec.rb
+++ b/spec/lib/guard/guardfile/evaluator_spec.rb
@@ -476,6 +476,12 @@ describe Guard::Guardfile::Evaluator do
           evaluator.reevaluate_guardfile
         end
       end
+
+      it 'configures the scope' do
+        expect(::Guard).to receive(:setup_scope)
+
+        evaluator.reevaluate_guardfile
+      end
     end
   end
 


### PR DESCRIPTION
Hello,

I was trying to focus on one of the plugins specified in my `Guardfile` and, hence, provided the `-P` option to the CLI.  When I started adjusting `Guardfile` later on, Guard was re-evaluating it as expected, but it wasn’t taking into account the CLI options.  I would appreciate any feedback. If it is the desired behavior, please do not hesitate to close the pull request.

Best wishes,
Ivan
