### PR TITLE
Allow tmux notifier to receive custom types.

### DIFF
--- a/lib/guard/notifiers/tmux.rb
+++ b/lib/guard/notifiers/tmux.rb
@@ -209,9 +209,8 @@ module Guard
       #
       def tmux_color(type, opts = {})
         type = type.to_sym
-        type = :default unless [:success, :failed, :pending].include?(type)
 
-        opts.fetch(type, DEFAULTS[type])
+        opts[type] || DEFAULTS[type] || opts[:default] || DEFAULTS[:default]
       end
 
       # Notification starting, save the current Tmux settings

--- a/spec/lib/guard/notifiers/tmux_spec.rb
+++ b/spec/lib/guard/notifiers/tmux_spec.rb
@@ -45,7 +45,7 @@ describe Guard::Notifier::Tmux do
 
   describe '#notify' do
     context 'with options passed at initialization' do
-      let(:notifier) { described_class.new(success: 'rainbow', silent: true) }
+      let(:notifier) { described_class.new(success: 'rainbow', silent: true, starting: 'vanilla') }
 
       it 'uses these options by default' do
         expect(Sheller).to receive(:run).
@@ -59,6 +59,13 @@ describe Guard::Notifier::Tmux do
           with('tmux set -q status-left-bg black') {}
 
         notifier.notify('any message', type: :success, success: 'black')
+      end
+
+      it 'uses the initialization options for custom types by default' do
+        expect(Sheller).to receive(:run).
+          with('tmux set -q status-left-bg vanilla') {}
+
+        notifier.notify('any message', type: :starting)
       end
     end
 
@@ -99,6 +106,27 @@ describe Guard::Notifier::Tmux do
         with('tmux set -q status-left-bg green') {}
 
       notifier.notify('any message', type: :notify)
+    end
+
+    it 'sets the tmux status bar color to default color on a custom type' do
+      expect(Sheller).to receive(:run).
+        with('tmux set -q status-left-bg black') {}
+
+      notifier.notify('any message', type: :custom, default: 'black')
+    end
+
+    it 'sets the tmux status bar color to default color on a custom type' do
+      expect(Sheller).to receive(:run).
+        with('tmux set -q status-left-bg green') {}
+
+      notifier.notify('any message', type: :custom)
+    end
+
+    it 'sets the tmux status bar color to passed color on a custom type' do
+      expect(Sheller).to receive(:run).
+        with('tmux set -q status-left-bg black') {}
+
+      notifier.notify('any message', type: :custom, custom: 'black')
     end
 
     context 'when right status bar is passed in as an option' do


### PR DESCRIPTION
This allows the tmux notifier to receive notifications types like
:starting (for instance, when the tests start running).

It will work with the same precedence rules as the already known types.

See issue #488 for my previous comments on why this could be interesting.
