### PR TITLE
Fix failing bug when running tasks with scope

### DIFF
--- a/lib/guard/dsl_describer.rb
+++ b/lib/guard/dsl_describer.rb
@@ -28,6 +28,7 @@ module Guard
       @options = options
       ::Guard.reset_groups
       ::Guard.reset_plugins
+      ::Guard.reset_scope
     end
 
     # List the Guard plugins that are available for use in your system and marks


### PR DESCRIPTION
When there is scope settings in Guardfile and run a task like `guard
list`, it fails with:

```
ERROR - Invalid Guardfile, original error is:
> [#] undefined method `[]=' for nil:NilClass
/path/to/guard/lib/guard/setuper.rb:98:in `block in setup_scope': undefined method `[]=' for nil:NilClass (NoMethodError)
```

`guard list` calls `DslDescriber#list` and it calls `#_evaluate_guardfile` directly and then `Dsl.scope` calls `Guard.setup_scope` but `@scope` is not initialized.

This is caused by `DslDescriber#initialize`. It doesn't call `Guard.reset_scope` while `Guard.setup` calls `_load_guardfile` which calls `evaluate_guardfile` after `_reset_all`.
