### PR TITLE
Fix gemspec, file man/guard.2 does not exist

### DIFF
--- a/guard.gemspec
+++ b/guard.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'formatador', '>= 0.2.4'
 
   s.files        = Dir.glob('{bin,images,lib}/**/*') \
-    + %w(CHANGELOG.md LICENSE man/guard.2 man/guard.1.html README.md)
+    + %w(CHANGELOG.md LICENSE man/guard.1 man/guard.1.html README.md)
   s.executable   = 'guard'
   s.require_path = 'lib'
 end


### PR DESCRIPTION
Fixes the following warning when installing latest guard's master:

```
guard at path/to/guard did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but
that may not affect its functionality.
The validation message from Rubygems was:
  ["man/guard.2"] are not files
```
