### PR TITLE
refactor interactors

### DIFF
--- a/lib/guard/commands/all.rb
+++ b/lib/guard/commands/all.rb
@@ -1,4 +1,5 @@
 # required for async_queue_add
+require "pry"
 require "guard"
 
 module Guard
@@ -33,5 +34,3 @@ module Guard
     end
   end
 end
-
-Guard::Commands::All.import

--- a/lib/guard/commands/change.rb
+++ b/lib/guard/commands/change.rb
@@ -1,3 +1,5 @@
+require "pry"
+
 module Guard
   module Commands
     class Change
@@ -25,5 +27,3 @@ module Guard
     end
   end
 end
-
-Guard::Commands::Change.import

--- a/lib/guard/commands/notification.rb
+++ b/lib/guard/commands/notification.rb
@@ -1,3 +1,5 @@
+require "pry"
+
 require "guard/notifier"
 
 module Guard
@@ -22,5 +24,3 @@ module Guard
     end
   end
 end
-
-Guard::Commands::Notification.import

--- a/lib/guard/commands/pause.rb
+++ b/lib/guard/commands/pause.rb
@@ -1,3 +1,5 @@
+require "pry"
+
 module Guard
   module Commands
     class Pause
@@ -23,5 +25,3 @@ module Guard
     end
   end
 end
-
-Guard::Commands::Pause.import

--- a/lib/guard/commands/reload.rb
+++ b/lib/guard/commands/reload.rb
@@ -1,3 +1,5 @@
+require "pry"
+
 module Guard
   module Commands
     class Reload
@@ -30,5 +32,3 @@ module Guard
     end
   end
 end
-
-Guard::Commands::Reload.import

--- a/lib/guard/commands/scope.rb
+++ b/lib/guard/commands/scope.rb
@@ -1,3 +1,5 @@
+require "pry"
+
 module Guard
   module Commands
     class Scope
@@ -32,5 +34,3 @@ module Guard
     end
   end
 end
-
-Guard::Commands::Scope.import

--- a/lib/guard/commands/show.rb
+++ b/lib/guard/commands/show.rb
@@ -1,3 +1,5 @@
+require "pry"
+
 module Guard
   module Commands
     class Show
@@ -20,5 +22,3 @@ module Guard
     end
   end
 end
-
-Guard::Commands::Show.import

--- a/lib/guard/interactor.rb
+++ b/lib/guard/interactor.rb
@@ -1,74 +1,55 @@
-require "pry"
-
-require "guard/commands/all"
-require "guard/commands/change"
-require "guard/commands/notification"
-require "guard/commands/pause"
-require "guard/commands/reload"
-require "guard/commands/scope"
-require "guard/commands/show"
 require "guard/ui"
 
+require "guard/jobs/sleep"
+require "guard/jobs/pry_wrapper"
+
 module Guard
-  # The Guard interactor is a Pry REPL with a Guard
-  # specific command set.
-  #
   class Interactor
-    # The default Ruby script to configure Guard Pry if the option `:guard_rc`
-    # is not defined.
-    GUARD_RC = "~/.guardrc"
+    # Initializes the interactor. This configures
+    # Pry and creates some custom commands and aliases
+    # for Guard.
+    #
+    def initialize(no_interaction = false)
+      @interactive = !no_interaction && self.class.enabled?
 
-    # The default Guard Pry history file if the option `:history_file` is not
-    # defined.
-    HISTORY_FILE = "~/.guard_history"
+      job_klass = interactive? ? Jobs::PryWrapper : Jobs::Sleep
+      @idle_job = job_klass.new(self.class.options)
+    end
 
-    # List of shortcuts for each interactor command
-    SHORTCUTS = {
-      help:         "h",
-      all:          "a",
-      reload:       "r",
-      change:       "c",
-      show:         "s",
-      scope:        "o",
-      notification: "n",
-      pause:        "p",
-      exit:         "e",
-      quit:         "q"
-    }
+    def interactive?
+      @interactive
+    end
 
-    attr_accessor :thread
+    # Run in foreground and wait until interrupted or closed
+    def foreground
+      idle_job.foreground
+    end
+
+    # Remove interactor so other tasks can run in foreground
+    def background
+      idle_job.background
+    end
+
+    def handle_interrupt
+      idle_job.handle_interrupt
+    end
 
     class << self
-      # Get the interactor options
-      #
-      # @return [Hash] the options
-      #
       def options
         @options ||= {}
       end
 
-      # Set the interactor options
-      #
-      # @param [Hash] options the interactor options
-      # @option options [String] :guard_rc Ruby script to configure Guard Pry
-      # @option options [String] :history_file for saving Pry history
-      #
+      # Pass options to interactor's job when it's created
       attr_writer :options
 
-      # Is the interactor enabled?
-      #
-      # @return [Boolean] true if enabled
-      #
+      # TODO: allow custom user idle jobs, e.g. [:pry, :sleep, :exit, ...]
       def enabled?
         @enabled || @enabled.nil?
       end
 
       alias_method :enabled, :enabled?
 
-      # Set the enabled status for the interactor
-      #
-      # @param [Boolean] status true if enabled
-      #
+      # TODO: handle switching interactors during runtime?
       attr_writer :enabled
 
       # Converts and validates a plain text scope
@@ -78,6 +59,7 @@ module Guard
       # @return [Hash, Array<String>] the plugin or group scope, the unknown
       #   entries
       #
+      # TODO: call this from within action, not within interactor command
       def convert_scope(entries)
         scopes  = { plugins: [], groups: [] }
         unknown = []
@@ -96,293 +78,8 @@ module Guard
       end
     end
 
-    # Initializes the interactor. This configures
-    # Pry and creates some custom commands and aliases
-    # for Guard.
-    #
-    def initialize(no_interaction = false)
-      @interactive = !no_interaction && self.class.enabled?
-      @mutex = Mutex.new
-      @thread = nil
-      @stty_exists = nil
-
-      return if ENV["GUARD_ENV"] == "test"
-
-      _pry_setup if interactive?
-    end
-
-    def interactive?
-      @interactive
-    end
-
-    # Run in foreground and wait until interrupted or closed
-    def foreground
-      return if ENV["GUARD_ENV"] == "test"
-      ::Guard::UI.debug "Start interactor"
-      _store_terminal_settings if _stty_exists?
-
-      interactive? ?  _interactive_foreground : _non_interactive_foreground
-    end
-
-    # Remove interactor so other tasks can run in foreground
-    def background
-      if interactive?
-        @mutex.synchronize do
-          unless @thread.nil?
-            @thread.kill
-            @thread = nil # set to nil so we know we were killed
-          end
-        end
-        _cleanup
-        return @thread.nil? ? :stopped : :exit
-      else
-        Thread.main.wakeup
-      end
-    end
-
-    # This is called from signal handler, so avoid actually
-    # doing anything other than signaling threads
-    def handle_interrupt
-      return if ENV["GUARD_ENV"] == "test"
-
-      if interactive?
-        # TODO: does this actually do anything?
-        if @thread
-          @thread.raise Interrupt
-        else
-          fail Interrupt
-        end
-      else
-        Thread.main.raise Interrupt
-      end
-    end
-
     private
 
-    # Add Pry hooks:
-    #
-    # * Load `~/.guardrc` within each new Pry session.
-    # * Load project's `.guardrc` within each new Pry session.
-    # * Restore prompt after each evaluation.
-    #
-    def _add_hooks
-      _add_load_guard_rc_hook
-      _add_load_project_guard_rc_hook
-      _add_restore_visibility_hook if _stty_exists?
-    end
-
-    # Add a `when_started` hook that loads a global .guardrc if it exists.
-    #
-    def _add_load_guard_rc_hook
-      Pry.config.hooks.add_hook :when_started, :load_guard_rc do
-        (self.class.options[:guard_rc] || GUARD_RC).tap do |p|
-          load p if File.exist?(File.expand_path(p))
-        end
-      end
-    end
-
-    # Add a `when_started` hook that loads a project .guardrc if it exists.
-    #
-    def _add_load_project_guard_rc_hook
-      Pry.config.hooks.add_hook :when_started, :load_project_guard_rc do
-        project_guard_rc = Dir.pwd + "/.guardrc"
-        load project_guard_rc if File.exist?(project_guard_rc)
-      end
-    end
-
-    # Add a `after_eval` hook that restores visibility after a command is eval.
-    #
-    def _add_restore_visibility_hook
-      Pry.config.hooks.add_hook :after_eval, :restore_visibility do
-        ::Guard::Sheller.run("stty echo 2>#{ DEV_NULL }")
-      end
-    end
-
-    # Replaces reset defined inside of Pry with a reset that
-    # instead restarts guard.
-    #
-    def _replace_reset_command
-      Pry.commands.command "reset", "Reset the Guard to a clean state." do
-        output.puts "Guard reset."
-        exec "guard"
-      end
-    end
-
-    # Creates a command that triggers the `:run_all` action
-    # when the command is empty (just pressing enter on the
-    # beginning of a line).
-    #
-    def _create_run_all_command
-      Pry.commands.block_command(/^$/, "Hit enter to run all") do
-        Pry.run_command "all"
-      end
-    end
-
-    # Creates command aliases for the commands: `help`, `reload`, `change`,
-    # `scope`, `notification`, `pause`, `exit` and `quit`, which will be the
-    # first letter of the command.
-    #
-    def _create_command_aliases
-      SHORTCUTS.each do |command, shortcut|
-        Pry.commands.alias_command shortcut, command.to_s
-      end
-    end
-
-    # Create a shorthand command to run the `:run_all`
-    # action on a specific Guard plugin. For example,
-    # when guard-rspec is available, then a command
-    # `rspec` is created that runs `all rspec`.
-    #
-    def _create_guard_commands
-      ::Guard.plugins.each do |guard_plugin|
-        cmd = "Run all #{ guard_plugin.title }"
-        Pry.commands.create_command guard_plugin.name, cmd do
-          group "Guard"
-
-          def process
-            Pry.run_command "all #{ match }"
-          end
-        end
-      end
-    end
-
-    # Create a shorthand command to run the `:run_all`
-    # action on a specific Guard group. For example,
-    # when you have a group `frontend`, then a command
-    # `frontend` is created that runs `all frontend`.
-    #
-    def _create_group_commands
-      ::Guard.groups.each do |group|
-        next if group.name == :default
-
-        cmd = "Run all #{ group.title }"
-        Pry.commands.create_command group.name.to_s, cmd  do
-          group "Guard"
-
-          def process
-            Pry.run_command "all #{ match }"
-          end
-        end
-      end
-    end
-
-    # Configures the pry prompt to see `guard` instead of
-    # `pry`.
-    #
-    def _configure_prompt
-      Pry.config.prompt = [_prompt(">"), _prompt("*")]
-    end
-
-    # Returns the plugins scope, or the groups scope ready for display in the
-    # prompt.
-    #
-    def _scope_for_prompt
-      scope_name = [:plugins, :groups].detect do |name|
-        ! ::Guard.scope[name].empty?
-      end
-      scope_name ? "#{_join_scope_for_prompt(scope_name)} " : ""
-    end
-
-    # Joins the scope corresponding to the given scope name with commas.
-    #
-    def _join_scope_for_prompt(scope_name)
-      ::Guard.scope[scope_name].map(&:title).join(",")
-    end
-
-    # Returns a proc that will return itself a string ending with the given
-    # `ending_char` when called.
-    #
-    def _prompt(ending_char)
-      proc do |target_self, nest_level, pry|
-        history = pry.input_array.size
-        process = ::Guard.listener.paused? ? "pause" : "guard"
-        level   = ":#{ nest_level }" unless nest_level.zero?
-
-        "[#{ history }] #{ _scope_for_prompt }#{ process }"\
-          "(#{ _clip_name(target_self) })#{ level }#{ ending_char } "
-      end
-    end
-
-    def _clip_name(target)
-      Pry.view_clip(target)
-    end
-
-    # Detects whether or not the stty command exists
-    # on the user machine.
-    #
-    # @return [Boolean] the status of stty
-    #
-    def _stty_exists?
-      return @stty_exists unless @stty_exists.nil?
-      @stty_exists = ::Guard::Sheller.run("hash", "stty") || false
-    end
-
-    # Stores the terminal settings so we can resore them
-    # when stopping.
-    #
-    def _store_terminal_settings
-      @stty_save = ::Guard::Sheller.stdout("stty -g 2>#{ DEV_NULL }").chomp
-    end
-
-    # Restore terminal settings
-    #
-    def _restore_terminal_settings
-      ::Guard::Sheller.run("stty #{ @stty_save } 2>#{ DEV_NULL }") if @stty_save
-    end
-
-    # Restore terminal settings after closing
-    def _cleanup
-      ::Guard::UI.reset_line
-      ::Guard::UI.debug "Stop interactor"
-      _restore_terminal_settings if _stty_exists?
-    end
-
-    # Enter interactive mode
-    def _block
-      return @thread.join if interactive?
-
-      STDERR.puts "Guards jobs done. Sleeping..."
-      sleep
-    end
-
-    def _pry_setup
-      Pry.config.should_load_rc = false
-      Pry.config.should_load_local_rc = false
-      history_file_path = self.class.options[:history_file] || HISTORY_FILE
-      Pry.config.history.file = File.expand_path(history_file_path)
-
-      _add_hooks
-      _setup_commands
-      _configure_prompt
-    end
-
-    def _non_interactive_foreground
-      _block
-      :stopped
-    rescue Interrupt
-      :exit
-    ensure
-      _cleanup
-    end
-
-    def _interactive_foreground
-      @mutex.synchronize do
-        unless @thread
-          @thread = Thread.new { Pry.start }
-          @thread.join(0.5) # give pry a chance to start
-        end
-      end
-      _block
-      _cleanup
-      @thread.nil? ? :stopped : :exit
-    end
-
-    def _setup_commands
-      _replace_reset_command
-      _create_run_all_command
-      _create_command_aliases
-      _create_guard_commands
-      _create_group_commands
-    end
+    attr_reader :idle_job
   end
 end

--- a/lib/guard/jobs/base.rb
+++ b/lib/guard/jobs/base.rb
@@ -1,0 +1,21 @@
+module Guard
+  module Jobs
+    class Base
+      def initialize(_options)
+      end
+
+      # @return [Symbol] :stopped once job is finished
+      # @return [Symbol] :exit to tell Guard to terminate
+      def foreground
+      end
+
+      def background
+      end
+
+      # Signal handler calls this, so avoid actually doing
+      # anything other than signaling threads
+      def handle_interrupt
+      end
+    end
+  end
+end

--- a/lib/guard/jobs/pry_wrapper.rb
+++ b/lib/guard/jobs/pry_wrapper.rb
@@ -1,0 +1,293 @@
+require "guard/commands/all"
+require "guard/commands/change"
+require "guard/commands/notification"
+require "guard/commands/pause"
+require "guard/commands/reload"
+require "guard/commands/scope"
+require "guard/commands/show"
+
+require "guard/jobs/base"
+
+module Guard
+  module Jobs
+    class TerminalSettings
+      def initialize
+        @settings = nil
+        @works = ::Guard::Sheller.run("hash", "stty") || false
+      end
+
+      def restore
+        return unless configurable? && @settings
+        ::Guard::Sheller.run("stty #{ @setting } 2>#{ DEV_NULL }")
+      end
+
+      def save
+        return unless configurable?
+        @settings = ::Guard::Sheller.stdout("stty -g 2>#{ DEV_NULL }").chomp
+      end
+
+      def echo
+        return unless configurable?
+        ::Guard::Sheller.run("stty echo 2>#{ DEV_NULL }")
+      end
+
+      def configurable?
+        @works
+      end
+    end
+
+    class PryWrapper < Base
+      # The default Ruby script to configure Guard Pry if the option `:guard_rc`
+      # is not defined.
+      GUARD_RC = "~/.guardrc"
+
+      # The default Guard Pry history file if the option `:history_file` is not
+      # defined.
+      HISTORY_FILE = "~/.guard_history"
+
+      # List of shortcuts for each interactor command
+      SHORTCUTS = {
+        help:         "h",
+        all:          "a",
+        reload:       "r",
+        change:       "c",
+        show:         "s",
+        scope:        "o",
+        notification: "n",
+        pause:        "p",
+        exit:         "e",
+        quit:         "q"
+      }
+
+      def initialize(options)
+        @mutex = Mutex.new
+        @thread = nil
+        @terminal_settings = TerminalSettings.new
+
+        _setup(options)
+      end
+
+      def foreground
+        ::Guard::UI.debug "Start interactor"
+        @terminal_settings.save
+
+        _start_pry
+        @thread.join
+        thread = @thread
+        thread.nil? ? :stopped : :exit
+      ensure
+        ::Guard::UI.reset_line
+        ::Guard::UI.debug "Interactor was stopped or killed"
+        @terminal_settings.restore
+      end
+
+      def background
+        _kill_pry
+      end
+
+      def handle_interrupt
+        thread = @thread
+        fail Interrupt unless thread
+        thread.raise Interrupt
+      end
+
+      private
+
+      attr_reader :thread
+
+      def _start_pry
+        @mutex.synchronize do
+          unless @thread
+            @thread = Thread.new { Pry.start }
+            @thread.join(0.5) # give pry a chance to start
+          end
+        end
+      end
+
+      def _kill_pry
+        @mutex.synchronize do
+          unless @thread.nil?
+            @thread.kill
+            @thread = nil # set to nil so we know we were killed
+          end
+        end
+      end
+
+      def _setup(options)
+        Pry.config.should_load_rc = false
+        Pry.config.should_load_local_rc = false
+        history_file_path = options[:history_file] || HISTORY_FILE
+        Pry.config.history.file = File.expand_path(history_file_path)
+
+        _add_hooks
+
+        Guard::Commands::All.import
+        Guard::Commands::Change.import
+        Guard::Commands::Notification.import
+        Guard::Commands::Pause.import
+        Guard::Commands::Reload.import
+        Guard::Commands::Show.import
+        Guard::Commands::Scope.import
+
+        _setup_commands
+        _configure_prompt
+      end
+
+      # Add Pry hooks:
+      #
+      # * Load `~/.guardrc` within each new Pry session.
+      # * Load project's `.guardrc` within each new Pry session.
+      # * Restore prompt after each evaluation.
+      #
+      def _add_hooks
+        _add_load_guard_rc_hook
+        _add_load_project_guard_rc_hook
+        _add_restore_visibility_hook if @terminal_settings.configurable?
+      end
+
+      # Add a `when_started` hook that loads a global .guardrc if it exists.
+      #
+      def _add_load_guard_rc_hook
+        Pry.config.hooks.add_hook :when_started, :load_guard_rc do
+          (self.class.options[:guard_rc] || GUARD_RC).tap do |p|
+            load p if File.exist?(File.expand_path(p))
+          end
+        end
+      end
+
+      # Add a `when_started` hook that loads a project .guardrc if it exists.
+      #
+      def _add_load_project_guard_rc_hook
+        Pry.config.hooks.add_hook :when_started, :load_project_guard_rc do
+          project_guard_rc = Dir.pwd + "/.guardrc"
+          load project_guard_rc if File.exist?(project_guard_rc)
+        end
+      end
+
+      # Add a `after_eval` hook that restores visibility after a command is
+      # eval.
+      def _add_restore_visibility_hook
+        Pry.config.hooks.add_hook :after_eval, :restore_visibility do
+          @terminal_settings.echo
+        end
+      end
+
+      def _setup_commands
+        _replace_reset_command
+        _create_run_all_command
+        _create_command_aliases
+        _create_guard_commands
+        _create_group_commands
+      end
+
+      # Replaces reset defined inside of Pry with a reset that
+      # instead restarts guard.
+      #
+      def _replace_reset_command
+        Pry.commands.command "reset", "Reset the Guard to a clean state." do
+          output.puts "Guard reset."
+          exec "guard"
+        end
+      end
+
+      # Creates a command that triggers the `:run_all` action
+      # when the command is empty (just pressing enter on the
+      # beginning of a line).
+      #
+      def _create_run_all_command
+        Pry.commands.block_command(/^$/, "Hit enter to run all") do
+          Pry.run_command "all"
+        end
+      end
+
+      # Creates command aliases for the commands: `help`, `reload`, `change`,
+      # `scope`, `notification`, `pause`, `exit` and `quit`, which will be the
+      # first letter of the command.
+      #
+      def _create_command_aliases
+        SHORTCUTS.each do |command, shortcut|
+          Pry.commands.alias_command shortcut, command.to_s
+        end
+      end
+
+      # Create a shorthand command to run the `:run_all`
+      # action on a specific Guard plugin. For example,
+      # when guard-rspec is available, then a command
+      # `rspec` is created that runs `all rspec`.
+      #
+      def _create_guard_commands
+        ::Guard.plugins.each do |guard_plugin|
+          cmd = "Run all #{ guard_plugin.title }"
+          Pry.commands.create_command guard_plugin.name, cmd do
+            group "Guard"
+
+            def process
+              Pry.run_command "all #{ match }"
+            end
+          end
+        end
+      end
+
+      # Create a shorthand command to run the `:run_all`
+      # action on a specific Guard group. For example,
+      # when you have a group `frontend`, then a command
+      # `frontend` is created that runs `all frontend`.
+      #
+      def _create_group_commands
+        ::Guard.groups.each do |group|
+          next if group.name == :default
+
+          cmd = "Run all #{ group.title }"
+          Pry.commands.create_command group.name.to_s, cmd  do
+            group "Guard"
+
+            def process
+              Pry.run_command "all #{ match }"
+            end
+          end
+        end
+      end
+
+      # Configures the pry prompt to see `guard` instead of
+      # `pry`.
+      #
+      def _configure_prompt
+        Pry.config.prompt = [_prompt(">"), _prompt("*")]
+      end
+
+      # Returns the plugins scope, or the groups scope ready for display in the
+      # prompt.
+      #
+      def _scope_for_prompt
+        scope_name = [:plugins, :groups].detect do |name|
+          ! ::Guard.scope[name].empty?
+        end
+        scope_name ? "#{_join_scope_for_prompt(scope_name)} " : ""
+      end
+
+      # Joins the scope corresponding to the given scope name with commas.
+      #
+      def _join_scope_for_prompt(scope_name)
+        ::Guard.scope[scope_name].map(&:title).join(",")
+      end
+
+      # Returns a proc that will return itself a string ending with the given
+      # `ending_char` when called.
+      #
+      def _prompt(ending_char)
+        proc do |target_self, nest_level, pry|
+          history = pry.input_array.size
+          process = ::Guard.listener.paused? ? "pause" : "guard"
+          level   = ":#{ nest_level }" unless nest_level.zero?
+
+          "[#{ history }] #{ _scope_for_prompt }#{ process }"\
+            "(#{ _clip_name(target_self) })#{ level }#{ ending_char } "
+        end
+      end
+
+      def _clip_name(target)
+        Pry.view_clip(target)
+      end
+    end
+  end
+end

--- a/lib/guard/jobs/sleep.rb
+++ b/lib/guard/jobs/sleep.rb
@@ -1,0 +1,25 @@
+require "guard/jobs/base"
+
+module Guard
+  module Jobs
+    class Sleep < Base
+      def foreground
+        ::Guard::UI.debug "Guards jobs done. Sleeping..."
+        sleep
+        ::Guard::UI.debug "Sleep interrupted by events."
+        :stopped
+      rescue Interrupt
+        ::Guard::UI.debug "Sleep interrupted by user."
+        :exit
+      end
+
+      def background
+        Thread.main.wakeup
+      end
+
+      def handle_interrupt
+        Thread.main.raise Interrupt
+      end
+    end
+  end
+end

--- a/spec/guard_spec.rb
+++ b/spec/guard_spec.rb
@@ -2,6 +2,11 @@ require "spec_helper"
 require "guard/plugin"
 
 describe Guard do
+  let(:interactor) { instance_double(Guard::Interactor) }
+  before do
+    allow(Guard::Interactor).to receive(:new).and_return(interactor)
+  end
+
   describe ".plugins" do
     before do
       stub_const "Guard::FooBar", Class.new(Guard::Plugin)
@@ -216,6 +221,7 @@ describe Guard do
   end
 
   describe ".group" do
+
     subject do
       allow(Guard::Notifier).to receive(:turn_on)
       allow(Listen).to receive(:to).with(Dir.pwd, {})

--- a/spec/lib/guard/commands/all_spec.rb
+++ b/spec/lib/guard/commands/all_spec.rb
@@ -1,7 +1,10 @@
 require "spec_helper"
 require "guard/plugin"
 
+require "guard/commands/all"
+
 describe Guard::Commands::All do
+  before { described_class.import }
 
   let(:foo_group) { instance_double(Guard::Group) }
   let(:bar_guard) { instance_double(Guard::PluginUtil) }

--- a/spec/lib/guard/commands/change_spec.rb
+++ b/spec/lib/guard/commands/change_spec.rb
@@ -1,6 +1,9 @@
 require "spec_helper"
 
+require "guard/commands/change"
+
 describe Guard::Commands::Change do
+  before { described_class.import }
   context "with a file" do
     it "runs the :run_on_changes action with the given file" do
       expect(::Guard).to receive(:async_queue_add).

--- a/spec/lib/guard/commands/notification_spec.rb
+++ b/spec/lib/guard/commands/notification_spec.rb
@@ -1,6 +1,9 @@
 require "spec_helper"
 
+require "guard/commands/notification"
+
 describe Guard::Commands::Notification do
+  before { described_class.import }
   it "toggles the Guard notifier" do
     expect(::Guard::Notifier).to receive(:toggle)
     Pry.run_command "notification"

--- a/spec/lib/guard/commands/pause_spec.rb
+++ b/spec/lib/guard/commands/pause_spec.rb
@@ -1,6 +1,9 @@
 require "spec_helper"
 
+require "guard/commands/pause"
+
 describe Guard::Commands::Pause do
+  before { described_class.import }
   it "tells Guard to pause" do
     expect(::Guard).to receive(:async_queue_add).with([:guard_pause])
     Pry.run_command "pause"

--- a/spec/lib/guard/commands/reload_spec.rb
+++ b/spec/lib/guard/commands/reload_spec.rb
@@ -1,7 +1,10 @@
 require "spec_helper"
 require "guard/plugin"
 
+require "guard/commands/reload"
+
 describe Guard::Commands::Reload do
+  before { described_class.import }
 
   let(:foo_group) { instance_double(Guard::Group) }
   let(:bar_guard) { instance_double(Guard::PluginUtil) }

--- a/spec/lib/guard/commands/scope_spec.rb
+++ b/spec/lib/guard/commands/scope_spec.rb
@@ -1,7 +1,10 @@
 require "spec_helper"
 require "guard/plugin"
 
+require "guard/commands/scope"
+
 describe Guard::Commands::Scope do
+  before { described_class.import }
 
   let(:foo_group) { instance_double(Guard::Group) }
   let(:bar_guard) { instance_double(Guard::PluginUtil) }

--- a/spec/lib/guard/commands/show_spec.rb
+++ b/spec/lib/guard/commands/show_spec.rb
@@ -1,6 +1,9 @@
 require "spec_helper"
 
+require "guard/commands/show"
+
 describe Guard::Commands::Show do
+  before { described_class.import }
   it "tells Guard to output DSL description" do
     expect(::Guard).to receive(:async_queue_add).with([:guard_show])
     Pry.run_command "show"

--- a/spec/lib/guard/dsl_describer_spec.rb
+++ b/spec/lib/guard/dsl_describer_spec.rb
@@ -5,6 +5,7 @@ require "guard/dsl_describer"
 require "formatador"
 
 describe Guard::DslDescriber do
+  let(:interactor) { instance_double(Guard::Interactor) }
 
   let(:guardfile) do
     <<-GUARDFILE
@@ -31,6 +32,7 @@ describe Guard::DslDescriber do
   end
 
   before do
+    allow(Guard::Interactor).to receive(:new).and_return(interactor)
     allow(Guard::Notifier).to receive(:turn_on)
     allow(::Guard).to receive(:add_builtin_plugins)
     allow(Listen).to receive(:to).with(Dir.pwd, {})

--- a/spec/lib/guard/dsl_spec.rb
+++ b/spec/lib/guard/dsl_spec.rb
@@ -1,12 +1,15 @@
 require "spec_helper"
 require "guard/plugin"
 
+require "guard/dsl"
+
 describe Guard::Dsl do
 
   let(:local_guardfile) { File.join(Dir.pwd, "Guardfile") }
   let(:home_guardfile) { File.expand_path(File.join("~", ".Guardfile")) }
   let(:home_config) { File.expand_path(File.join("~", ".guard.rb")) }
   let(:guardfile_evaluator) { instance_double(Guard::Guardfile::Evaluator) }
+  let(:interactor) { instance_double(Guard::Interactor) }
 
   before do
     stub_const "Guard::Foo", Class.new(Guard::Plugin)
@@ -15,6 +18,7 @@ describe Guard::Dsl do
     allow(Guard::Notifier).to receive(:turn_on)
     allow(::Guard).to receive(:add_builtin_plugins)
     allow(Listen).to receive(:to).with(Dir.pwd, {})
+    allow(Guard::Interactor).to receive(:new).and_return(interactor)
     ::Guard.setup
   end
 

--- a/spec/lib/guard/jobs/pry_wrapper_spec.rb
+++ b/spec/lib/guard/jobs/pry_wrapper_spec.rb
@@ -1,0 +1,163 @@
+require "spec_helper"
+
+require "guard/jobs/pry_wrapper"
+
+describe Guard::Jobs::PryWrapper do
+  subject { described_class.new({}) }
+  let(:listener) { instance_double(Listen::Listener) }
+  let(:pry_config) { double("pry_config") }
+  let(:pry_history) { double("pry_history") }
+  let(:pry_commands) { double("pry_commands") }
+  let(:pry_hooks) { double("pry_hooks") }
+
+  before do
+    # TODO: this are here to mock out Pry completely
+    allow(pry_config).to receive(:prompt=)
+    allow(pry_config).to receive(:should_load_rc=)
+    allow(pry_config).to receive(:should_load_local_rc=)
+    allow(pry_config).to receive(:hooks).and_return(pry_hooks)
+    allow(pry_config).to receive(:history).and_return(pry_history)
+    allow(pry_config).to receive(:commands).and_return(pry_commands)
+    allow(pry_history).to receive(:file=)
+    allow(pry_commands).to receive(:alias_command)
+    allow(pry_commands).to receive(:create_command)
+    allow(pry_commands).to receive(:command)
+    allow(pry_commands).to receive(:block_command)
+    allow(pry_hooks).to receive(:add_hook)
+
+    allow(Guard).to receive(:listener).and_return(listener)
+    allow(Pry).to receive(:config).and_return(pry_config)
+    allow(Guard::Sheller).to receive(:run).with(*%w(hash stty)) { false }
+  end
+
+  describe "#foreground" do
+
+    before do
+      allow(Pry).to receive(:start) do
+        # sleep for a long time (anything > 0.6)
+        sleep 2
+      end
+    end
+
+    after do
+      subject.background
+    end
+
+    it "waits for Pry thread to finish" do
+      was_alive = false
+
+      Thread.new do
+        sleep 0.1
+        was_alive = subject.send(:thread).alive?
+        subject.background
+      end
+
+      subject.foreground # blocks
+      expect(was_alive).to be
+    end
+
+    it "prevents the Pry thread from being killed too quickly" do
+      start = Time.now.to_f
+
+      Thread.new do
+        sleep 0.1
+        subject.background
+      end
+
+      subject.foreground # blocks
+      killed_moment = Time.now.to_f
+
+      expect(killed_moment - start).to be > 0.5
+    end
+
+    it "return :stopped when brought into background" do
+      Thread.new do
+        sleep 0.1
+        subject.background
+      end
+
+      expect(subject.foreground).to be(:stopped)
+    end
+
+  end
+
+  describe "#background" do
+    before do
+      allow(Pry).to receive(:start) do
+        # 0.5 is enough for Pry, so we use 0.4
+        sleep 0.4
+      end
+    end
+
+    it "kills the Pry thread" do
+      subject.foreground
+      sleep 1 # give Pry 0.5 sec to boot
+      subject.background
+      sleep 0.25 # to let Pry get killed asynchronously
+
+      expect(subject.send(:thread)).to be_nil
+    end
+  end
+
+  describe "#_prompt(ending_char)" do
+    let(:prompt) { subject.send(:_prompt, ">") }
+
+    before do
+      allow(Guard::Sheller).to receive(:run).with(*%w(hash stty)) { false }
+      allow(::Guard).to receive(:scope).and_return({})
+      allow(::Guard.scope).to receive(:[]).with(:plugins).and_return([])
+      allow(::Guard.scope).to receive(:[]).with(:groups).and_return([])
+
+      allow(listener).to receive(:paused?).and_return(false)
+
+      expect(Pry).to receive(:view_clip).and_return("main")
+    end
+
+    let(:pry) { instance_double(Pry, input_array: []) }
+
+    context "Guard is not paused" do
+      it 'displays "guard"' do
+        expect(prompt.call(double, 0, pry)).
+          to eq "[0] guard(main)> "
+      end
+    end
+
+    context "Guard is paused" do
+      before do
+        allow(listener).to receive(:paused?).and_return(true)
+      end
+
+      it 'displays "pause"' do
+        expect(prompt.call(double, 0, pry)).
+          to eq "[0] pause(main)> "
+      end
+    end
+
+    context "with a groups scope" do
+      before do
+        allow(::Guard.scope).to receive(:[]).with(:groups).
+          and_return([double(title: "Backend"), double(title: "Frontend")])
+      end
+
+      it "displays the group scope title in the prompt" do
+        expect(prompt.call(double, 0, pry)).
+          to eq "[0] Backend,Frontend guard(main)> "
+
+      end
+    end
+
+    context "with a plugins scope" do
+
+      before do
+        allow(::Guard.scope).to receive(:[]).with(:plugins).
+          and_return([double(title: "RSpec"), double(title: "Ronn")])
+      end
+
+      it "displays the group scope title in the prompt" do
+        result = prompt.call(double, 0, pry)
+        expect(result).to eq "[0] RSpec,Ronn guard(main)> "
+      end
+    end
+
+  end
+end

--- a/spec/lib/guard/jobs/sleep_spec.rb
+++ b/spec/lib/guard/jobs/sleep_spec.rb
@@ -1,0 +1,49 @@
+require "spec_helper"
+
+require "guard/jobs/sleep"
+
+describe Guard::Jobs::Sleep do
+  subject { described_class.new({}) }
+
+  describe "#foreground" do
+    it "sleeps" do
+      status = "unknown"
+
+      Thread.new do
+        sleep 0.1
+        status = Thread.main.status
+        subject.background
+      end
+
+      subject.foreground
+
+      expect(status).to eq("sleep")
+    end
+
+    it "returns :stopped when put to background" do
+      Thread.new do
+        sleep 0.1
+        subject.background
+      end
+
+      expect(subject.foreground).to eq(:stopped)
+    end
+  end
+
+  describe "#background" do
+    it "wakes up main thread" do
+      status = "unknown"
+
+      Thread.new do
+        sleep 0.1
+        subject.background
+        status = Thread.main.status
+
+        Thread.main.wakeup # to get "red" in TDD without hanging
+      end
+
+      subject.foreground
+      expect(status).to eq("run")
+    end
+  end
+end

--- a/spec/lib/guard/plugin_util_spec.rb
+++ b/spec/lib/guard/plugin_util_spec.rb
@@ -9,9 +9,11 @@ describe Guard::PluginUtil do
   let!(:rubygems_version_1_8_0) { Gem::Version.create("1.8.0") }
   let(:guard_rspec_class) { class_double(Guard::RSpec) }
   let(:guard_rspec) { instance_double(Guard::RSpec) }
+  let(:interactor) { instance_double(Guard::Interactor) }
   let(:guardfile_evaluator) { instance_double(Guard::Guardfile::Evaluator) }
 
   before do
+    allow(Guard::Interactor).to receive(:new).and_return(interactor)
     allow(Listen).to receive(:to).with(Dir.pwd, {})
     allow(Guard::Notifier).to receive(:turn_on) {}
     Guard.setup

--- a/spec/lib/guard/runner_spec.rb
+++ b/spec/lib/guard/runner_spec.rb
@@ -3,6 +3,8 @@ require "guard/plugin"
 
 describe Guard::Runner do
 
+  let(:interactor) { instance_double(Guard::Interactor) }
+
   before do
     # These are implemented, because otherwise stubbing _scoped_plugins is too
     # much work
@@ -40,6 +42,7 @@ describe Guard::Runner do
       end
     end
 
+    allow(Guard::Interactor).to receive(:new).and_return(interactor)
     allow(Guard::Notifier).to receive(:turn_on) {}
     allow(Listen).to receive(:to).with(Dir.pwd, {})
 

--- a/spec/lib/guard/setuper_spec.rb
+++ b/spec/lib/guard/setuper_spec.rb
@@ -4,10 +4,14 @@ require "guard/plugin"
 describe Guard::Setuper do
 
   let(:guardfile_evaluator) { instance_double(Guard::Guardfile::Evaluator) }
+  let(:pry_interactor) { double(Guard::Jobs::PryWrapper) }
+  let(:sleep_interactor) { double(Guard::Jobs::Sleep) }
 
   before do
     Guard::Interactor.enabled = true
     allow(Dir).to receive(:chdir)
+    allow(Guard::Jobs::PryWrapper).to receive(:new).and_return(pry_interactor)
+    allow(Guard::Jobs::Sleep).to receive(:new).and_return(sleep_interactor)
   end
 
   describe ".setup" do
@@ -366,13 +370,6 @@ describe Guard::Setuper do
 
       context "when receiving SIGINT" do
         context "with an interactor" do
-          let(:interactor) do
-            instance_double(
-              Guard::Interactor,
-              thread: instance_double(Thread))
-          end
-          before { allow(Guard).to receive(:interactor) { interactor } }
-
           it "delegates to the Pry thread" do
             expect(Guard.interactor).to receive(:handle_interrupt)
             Process.kill :INT, Process.pid

--- a/spec/lib/guard/ui_spec.rb
+++ b/spec/lib/guard/ui_spec.rb
@@ -3,17 +3,13 @@ require "spec_helper"
 include Guard
 
 describe UI do
-  before { Guard.clear_options }
-  after do
-    UI.options = {
-      level: :info,
-      device: $stderr,
-      template: ":time - :severity - :message",
-      time_format: "%H:%M:%S"
-    }
-  end
+  let(:interactor) { instance_double(Guard::Interactor) }
 
   before do
+    allow(Guard::Interactor).to receive(:new).and_return(interactor)
+
+    Guard.clear_options
+
     allow(Notifier).to receive(:turn_on) {}
 
     # The spec helper stubs all UI classes, so other specs doesn't have
@@ -34,6 +30,13 @@ describe UI do
   end
 
   after do
+    UI.options = {
+      level: :info,
+      device: $stderr,
+      template: ":time - :severity - :message",
+      time_format: "%H:%M:%S"
+    }
+
     allow(::UI).to receive(:info)
     allow(::UI).to receive(:warning)
     allow(::UI).to receive(:error)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,8 +4,6 @@ Coveralls.wear!
 require "guard"
 require "rspec"
 
-ENV["GUARD_ENV"] = "test"
-
 path = "#{File.expand_path("..", __FILE__)}/support/**/*.rb"
 Dir[path].each { |f| require f }
 
@@ -83,9 +81,6 @@ RSpec.configure do |config|
   end
 
   config.after(:each) do
-    Pry.config.hooks.delete_hook(:when_started, :load_guard_rc)
-    Pry.config.hooks.delete_hook(:when_started, :load_project_guard_rc)
-
     Guard::Notifier.clear_notifiers
 
     ::Guard.options[:debug] = false if ::Guard.options


### PR DESCRIPTION
- split interactor into Sleep and PryWrapper, calling them "Jobs"
- mock out Pry usage everywhere (except command specs)
- allow better coverage of thread handling (PryWrapper)
- conveniently mock out Interactor from non-interactor related specs
- get rid of GUARD_ENV variable and usage (in specs)
