### PR TITLE
'guard init' keeps appending the same templates to Guardfile

### DIFF
--- a/lib/guard/cli.rb
+++ b/lib/guard/cli.rb
@@ -171,7 +171,14 @@ module Guard
       ::Guard.reset_options(options) # Since UI.deprecated uses config
       ::Guard.reset_evaluator(options) # for initialize_all_templates
 
+      # This is messed up (deprecated, etc) and will be fixed later
       ::Guard::Guardfile.create_guardfile(abort_on_existence: options[:bare])
+
+      # Note: this reset "hack" will be fixed after refactoring
+      ::Guard.reset_plugins
+
+      # Evaluate because it might have existed and creating was skipped
+      ::Guard.evaluator.evaluate_guardfile
 
       return if options[:bare]
 

--- a/lib/guard/guardfile/evaluator.rb
+++ b/lib/guard/guardfile/evaluator.rb
@@ -22,6 +22,7 @@ module Guard
       # content of a valid Guardfile
       #
       def initialize(opts = {})
+        @evaluated = false
         @source = nil
         @guardfile_path = nil
 
@@ -81,8 +82,8 @@ module Guard
       # @return [Boolean] whether the Guard plugin has been declared
       #
       def guardfile_include?(plugin_name)
-        regexp = /^guard\s*\(?\s*['":]#{ plugin_name }['"]?/
-        _guardfile_contents_without_user_config.match(regexp)
+        /^\s*guard\s*\(?\s*['":]#{ plugin_name }['"]?/.
+          match _guardfile_contents_without_user_config
       end
 
       # Gets the content of the `Guardfile` concatenated with the global
@@ -106,6 +107,7 @@ module Guard
       # @return [String] the Guardfile content
       #
       def _guardfile_contents_without_user_config
+        fail "BUG: no data - Guardfile wasn't evaluated" unless @evaluated
         @guardfile_contents || ""
       end
 
@@ -124,6 +126,7 @@ module Guard
       #
       def _fetch_guardfile_contents
         _use_inline || _use_provided || _use_default
+        @evaluated = true
 
         return if _guardfile_contents_usable?
         ::Guard::UI.error "No Guard plugins found in Guardfile,"\

--- a/spec/lib/guard/guardfile/evaluator_spec.rb
+++ b/spec/lib/guard/guardfile/evaluator_spec.rb
@@ -542,6 +542,13 @@ RSpec.describe Guard::Guardfile::Evaluator do
 
       expect(evaluator.guardfile_include?("test")).to be_truthy
     end
+
+    it "detects a guard preceded by space (in a group)" do
+      allow(evaluator).to receive(:_guardfile_contents_without_user_config).
+        and_return("group :foo do\n  guard :test do\n end\nend\n")
+
+      expect(evaluator.guardfile_include?("test")).to be_truthy
+    end
   end
 
   private


### PR DESCRIPTION
While the message suggests plugins are already present, they are still added.

How to reproduce:
1) create guardfile
2) run 'guard init' multiple times

result - Guardfile gets larger
