### PR TITLE
rework debugging/tracing features

### DIFF
--- a/lib/guard/internals/debugging.rb
+++ b/lib/guard/internals/debugging.rb
@@ -1,0 +1,66 @@
+# Because it's used by Sheller
+require "open3"
+
+require "guard/ui"
+
+require "guard/internals/tracing"
+
+module Guard
+  # @private api
+  module Internals
+    class Debugging
+      class << self
+        TRACES = [
+          [Kernel, :system],
+          [Kernel, :`],
+          [Open3, :popen3]
+        ]
+
+        # Sets up debugging:
+        #
+        # * aborts on thread exceptions
+        # * Set the logging level to `:debug`
+        # * traces execution of Kernel.system and backtick calls
+        def start
+          return if @started ||= false
+          @started = true
+
+          Thread.abort_on_exception = true
+
+          ::Guard::UI.level = Logger::DEBUG
+
+          TRACES.each { |mod, meth| _trace(mod, meth, &method(:_notify)) }
+          @traced = true
+        end
+
+        def stop
+          return unless @started ||= false
+          ::Guard::UI.level = Logger::INFO
+          _reset
+        end
+
+        private
+
+        def _notify(*args)
+          ::Guard::UI.debug "Command execution: #{args.join(" ")}"
+        end
+
+        # reset singleton - called by tests
+        def _reset
+          @started = false
+          return unless @traced
+          TRACES.each { |mod, meth| _untrace(mod, meth) }
+          @traced = false
+        end
+
+        def _trace(mod, meth, &block)
+          ::Guard::Internals::Tracing.trace(mod, meth, &block)
+        end
+
+        def _untrace(mod, meth)
+          ::Guard::Internals::Tracing.untrace(mod, meth)
+        end
+      end
+    end
+  end
+end

--- a/lib/guard/internals/tracing.rb
+++ b/lib/guard/internals/tracing.rb
@@ -1,0 +1,33 @@
+module Guard
+  module Internals
+    module Tracing
+      def self.trace(mod, meth)
+        meta = (class << mod; self; end)
+        original_meth = "original_#{meth}".to_sym
+
+        if mod.respond_to?(original_meth)
+          fail "ALREADY TRACED: #{mod}.#{meth}"
+        end
+
+        meta.send(:alias_method, original_meth, meth)
+        meta.send(:define_method, meth) do |*args, &block|
+          yield(*args) if block_given?
+          mod.send original_meth, *args, &block
+        end
+      end
+
+      def self.untrace(mod, meth)
+        meta = (class << mod; self; end)
+        original_meth = "original_#{meth}".to_sym
+
+        unless mod.respond_to?(original_meth)
+          fail "NOT TRACED: #{mod}.#{meth} (no method: #{original_meth})"
+        end
+
+        meta.send(:remove_method, meth)
+        meta.send(:alias_method, meth, original_meth)
+        meta.send(:undef_method, original_meth)
+      end
+    end
+  end
+end

--- a/lib/guard/ui.rb
+++ b/lib/guard/ui.rb
@@ -53,8 +53,14 @@ module Guard
       # @option options [String] template the logger template
       # @option options [String] time_format the time format
       #
+      # TODO: deprecate?
       def options=(options)
         @options = ::Guard::Options.new(options)
+      end
+
+      # Assigns a log level
+      def level=(new_level)
+        logger.level = new_level
       end
 
       # Show an info message.
@@ -135,7 +141,8 @@ module Guard
       end
 
       # TODO: arguments: UI uses Guard::options anyway
-      def setup(_options)
+      # @private api
+      def reset_and_clear
         @clearable = false
         clear(force: true)
       end

--- a/spec/lib/guard/internals/debugging_spec.rb
+++ b/spec/lib/guard/internals/debugging_spec.rb
@@ -1,0 +1,105 @@
+require "guard/internals/debugging"
+
+RSpec.describe Guard::Internals::Debugging do
+  let(:null) { Guard::DEV_NULL }
+  let(:ui) { class_double(::Guard::UI) }
+  let(:tracing) { class_spy(::Guard::Internals::Tracing) }
+  let(:thread_class) { class_double(Thread) }
+
+  before do
+    stub_const("::Guard::Internals::Tracing", tracing)
+    stub_const("::Guard::UI", ui)
+    stub_const("::Thread", thread_class)
+    allow(ui).to receive(:debug)
+    allow(ui).to receive(:level=)
+    allow(thread_class).to receive(:abort_on_exception=)
+  end
+
+  after do
+    described_class.send(:_reset)
+  end
+
+  describe "#start" do
+    it "traces Kernel.system" do
+      expect(tracing).to receive(:trace).with(Kernel, :system) do |*_, &block|
+        expect(ui).to receive(:debug).with("Command execution: foo")
+        block.call "foo"
+      end
+      described_class.start
+    end
+
+    it "traces Kernel.`" do
+      expect(tracing).to receive(:trace).with(Kernel, :`) do |*_, &block|
+        expect(ui).to receive(:debug).with("Command execution: foo")
+        block.call("foo")
+      end
+
+      described_class.start
+    end
+
+    it "traces Open3.popen3" do
+      expect(tracing).to receive(:trace).with(Open3, :popen3) do |*_, &block|
+        expect(ui).to receive(:debug).with("Command execution: foo")
+        block.call("foo")
+      end
+
+      described_class.start
+    end
+
+    context "when not started" do
+      before { described_class.start }
+
+      it "sets logger to debug" do
+        expect(ui).to have_received(:level=).with(Logger::DEBUG)
+      end
+
+      it "makes threads abort on exceptions" do
+        expect(thread_class).to have_received(:abort_on_exception=).with(true)
+      end
+    end
+
+    context "when already started" do
+      before do
+        allow(tracing).to receive(:trace)
+        described_class.start
+      end
+
+      it "does not set log level" do
+        expect(ui).to_not receive(:level=)
+        described_class.start
+      end
+    end
+  end
+
+  describe "#stop" do
+    context "when already started" do
+      before do
+        described_class.start
+        described_class.stop
+      end
+
+      it "sets logger level to info" do
+        expect(ui).to have_received(:level=).with(Logger::INFO)
+      end
+
+      it "untraces Kernel.system" do
+        expect(tracing).to have_received(:untrace).with(Kernel, :system)
+      end
+
+      it "untraces Kernel.`" do
+        expect(tracing).to have_received(:untrace).with(Kernel, :`)
+      end
+
+      it "untraces Open3.popen3" do
+        expect(tracing).to have_received(:untrace).with(Kernel, :popen3)
+      end
+    end
+
+    context "when not started" do
+      it "does not set logger level" do
+        described_class.stop
+        expect(ui).to_not have_received(:level=)
+      end
+    end
+  end
+end

--- a/spec/lib/guard/internals/tracing_spec.rb
+++ b/spec/lib/guard/internals/tracing_spec.rb
@@ -1,0 +1,113 @@
+require "guard/internals/tracing"
+
+RSpec.describe Guard::Internals::Tracing do
+  let(:null) { Guard::DEV_NULL }
+
+  # NOTE: Calling system() is different from calling Kernel.system()
+  #
+  # We can capture system() calls by stubbing Kernel.system, but to capture
+  # Kernel.system() calls, we need to stub the module's metaclass methods.
+  #
+  # Stubbing just Kernel.system isn't "deep" enough, but not only that,
+  # we don't want to stub here, we want to TEST the stubbing
+  #
+  describe "Module method tracing" do
+    let(:result) { Kernel.send(meth, *args) }
+    subject { result }
+
+    let(:callback) { double("callback", call: true) }
+
+    # Since we can't stub the C code in Ruby, only "right" way to test this is:
+    # actually call a real command and compare the output
+    before { allow(Kernel).to receive(meth).and_call_original }
+
+    context "when tracing" do
+      before do
+        described_class.trace(Kernel, meth) { |*args| callback.call(*args) }
+        subject
+      end
+
+      after { described_class.untrace(Kernel, meth) }
+
+      context "with no command arguments" do
+        let(:args) { ["echo >#{null}"] }
+
+        context "when #system" do
+          let(:meth) { "system" }
+
+          it { is_expected.to eq(true) }
+
+          it "outputs command" do
+            expect(callback).to have_received(:call).with("echo >#{null}")
+          end
+        end
+
+        context "when backticks" do
+          let(:meth) { :` }
+
+          it { is_expected.to eq("") }
+
+          it "outputs command" do
+            expect(callback).to have_received(:call).with("echo >#{null}")
+          end
+        end
+      end
+
+      context "with command arguments" do
+        let(:args) { %w(true 123) }
+
+        context "when #system" do
+          let(:meth) { "system" }
+
+          it { is_expected.to eq(true) }
+
+          it "outputs command arguments" do
+            expect(callback).to have_received(:call).with("true", "123")
+          end
+        end
+      end
+    end
+
+    context "when not tracing" do
+      before { subject }
+
+      context "with no command arguments" do
+        let(:args) { ["echo test > #{null}"] }
+
+        context "when #system" do
+          let(:meth) { :system }
+
+          it { is_expected.to eq(true) }
+
+          it "does not output anything" do
+            expect(callback).to_not have_received(:call)
+          end
+        end
+
+        context "when backticks" do
+          let(:meth) { :` }
+
+          it { is_expected.to eq("") }
+
+          it "does not output anything" do
+            expect(callback).to_not have_received(:call)
+          end
+        end
+      end
+
+      context "with command arguments" do
+        let(:args) { %w(true 123) }
+
+        context "when #system" do
+          let(:meth) { :system }
+
+          it { is_expected.to eq(true) }
+
+          it "does not output anything" do
+            expect(callback).to_not have_received(:call)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/guard/ui_spec.rb
+++ b/spec/lib/guard/ui_spec.rb
@@ -344,8 +344,7 @@ RSpec.describe Guard::UI do
         # disable avoid calling clear during before()
         allow(options).to receive(:[]).with(:clear).and_return(false)
 
-        # This shouldn't do anything except set instance var
-        Guard::UI.setup(options)
+        Guard::UI.reset_and_clear
       end
 
       context "when clear option is disabled" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -156,9 +156,6 @@ RSpec.configure do |config|
 
     Guard.clear_options
 
-    # Ensure debug command execution isn't used in the specs
-    allow(Guard).to receive(:_debug_command_execution)
-
     # Stub all UI methods, so no visible output appears for the UI class
     allow(::Guard::UI).to receive(:info)
     allow(::Guard::UI).to receive(:warning)


### PR DESCRIPTION
Tracing system calls stopped working after Sheller was introduced, because tracing system() is not the same as tracing Kernel.system().

(I broke it after merging the Sheller and I never noticed).

Now, when e.g. guard-rspec runs a command, it's visible in debug mode.
Also, any class/module method can be traced, e.g.

``` ruby
trace(Guard,:setup) { |options| Guard::UI.warn "setup(#{options.inspect})" }
```
