### PR TITLE
Longer deprecation message to identify fault

### DIFF
--- a/lib/guard/guard.rb
+++ b/lib/guard/guard.rb
@@ -42,7 +42,7 @@ module Guard
     If you don't know which gem or plugin is requiring this file, here's a
     backtrace:
 
-    #{Thread.current.backtrace[1..5].join("\n\t >> ")}"
+    #{Thread.current.backtrace[1..10].join("\n\t >> ")}"
 
     Here's how to quickly upgrade/fix this (given you are a maintainer of the
     offending plugin or you want to prepare a pull request yourself):


### PR DESCRIPTION
Recommend extending the deprecation backtrace to make it easy to find faults, as active_supports dependencies is pretty much all you get for 5 lines at the moment.
#### Example

```
     >> /Users/dave/.rvm/gems/ruby-2.1.2@phoenix/gems/guard-2.8.2/lib/guard/guard.rb:3:in `<top (required)>'
     >> /Users/dave/.rvm/gems/ruby-2.1.2@phoenix/gems/activesupport-3.2.17/lib/active_support/dependencies.rb:251:in `require'
     >> /Users/dave/.rvm/gems/ruby-2.1.2@phoenix/gems/activesupport-3.2.17/lib/active_support/dependencies.rb:251:in `block in require'
     >> /Users/dave/.rvm/gems/ruby-2.1.2@phoenix/gems/activesupport-3.2.17/lib/active_support/dependencies.rb:236:in `load_dependency'
     >> /Users/dave/.rvm/gems/ruby-2.1.2@phoenix/gems/activesupport-3.2.17/lib/active_support/dependencies.rb:251:in `require'

     >> /Users/dave/.rvm/gems/ruby-2.1.2@phoenix/gems/guard-jasmine-1.17.0/lib/guard/jasmine.rb:4:in `<top (required)>'
     >> /Users/dave/.rvm/gems/ruby-2.1.2@global/gems/bundler-1.6.2/lib/bundler/runtime.rb:85:in `require'
```

As you can see the stack trace at 5 lines in length is just not enough to expose the culprit.

Thanks
