### PR TITLE
fix broken notifications [close #680]

### DIFF
--- a/lib/guard/notifier.rb
+++ b/lib/guard/notifier.rb
@@ -85,6 +85,8 @@ module Guard
 
       return unless enabled? && options[:notify]
 
+      @detected.detect
+
       turn_on
     rescue Detected::NoneAvailableError => e
       ::Guard::UI.info e.to_s

--- a/spec/lib/guard/notifier_spec.rb
+++ b/spec/lib/guard/notifier_spec.rb
@@ -89,12 +89,22 @@ RSpec.describe Guard::Notifier do
           expect(env).to receive(:notify_pid=).with($$)
           subject.connect(options)
         end
+
+        it "autodetects" do
+          expect(detected).to receive(:detect)
+          subject.connect(options)
+        end
       end
 
       context "when disabled with options" do
         let(:options) { { notify: false } }
         it "assigns a pid anyway" do
           expect(env).to receive(:notify_pid=).with($$)
+          subject.connect(options)
+        end
+
+        it "does not autodetect" do
+          expect(detected).to_not receive(:detect)
           subject.connect(options)
         end
       end


### PR DESCRIPTION
Autodetection wasn't run, so there were no available notifiers
(unless the user manually set them)
