### PR TITLE
Print original errors while generating Guardfiles

### DIFF
--- a/lib/guard/guardfile/generator.rb
+++ b/lib/guard/guardfile/generator.rb
@@ -76,13 +76,14 @@ module Guard
 
         _ui(:info, format(INFO_TEMPLATE_ADDED, plugin_name))
 
-      rescue Errno::ENOENT
+      rescue Errno::ENOENT => error
 
         name = plugin_name.downcase
         class_name = name.gsub("-", "").capitalize
         _ui(:error, "Could not load 'guard/#{name}'"\
             " or '~/.guard/templates/#{name}'"\
             " or find class Guard::#{class_name}")
+        _ui(:error, "Error is: #{error}")
       end
 
       # Adds the templates of all installed Guard implementations to an

--- a/spec/lib/guard/guardfile/generator_spec.rb
+++ b/spec/lib/guard/guardfile/generator_spec.rb
@@ -121,6 +121,10 @@ RSpec.describe Guard::Guardfile::Generator do
           "Could not load 'guard/foo' or '~/.guard/templates/foo'"\
           " or find class Guard::Foo"
         )
+        expect(::Guard::UI).to receive(:error).with(
+          /Error is: No such file or directory/
+        )
+
         described_class.new.initialize_template("foo")
       end
     end


### PR DESCRIPTION
This is similar to regular plugin loading, but stack traces aren't helpful here.