### PR TITLE
Backward compatibility fix of Notifier.notify signature

### DIFF
--- a/lib/guard/notifier.rb
+++ b/lib/guard/notifier.rb
@@ -23,7 +23,7 @@ module Guard
     DEPRECATED_IMPLICIT_CONNECT = "Calling Notiffany::Notifier.notify()" +
       " without a prior Notifier.connect() is deprecated"
 
-    def self.notify(message, options)
+    def self.notify(message, options = {})
       unless @notifier
         # TODO: reenable again?
         # UI.deprecation(DEPRECTED_IMPLICIT_CONNECT)


### PR DESCRIPTION
Notifier.notify previously had only one required parameter. This behavior is expected by plugins.
I encountered this error when using a guard-sprockets.