### PR TITLE
Integrate the reload functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ coverage/
 man/guard
 man/guard.html
 /tags
+/tmp/

--- a/bin/_guard-core
+++ b/bin/_guard-core
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+require "guard"
+
+begin
+  require "guard/aruba_adapter"
+rescue LoadError => e
+  abort "#{e.inspect} - perhaps you need to run using `bundle exec`?"
+end
+
+Guard::ArubaAdapter.new(ARGV.dup).execute!

--- a/bin/guard
+++ b/bin/guard
@@ -1,11 +1,12 @@
 #!/usr/bin/env ruby
 
-require "guard"
+require "pathname"
+ENV["BUNDLE_GEMFILE"] ||= (Pathname(__FILE__).realpath + "../../Gemfile").to_s
 
-begin
-  require "guard/aruba_adapter"
-rescue LoadError => e
-  abort "#{e.inspect} - perhaps you need to run using `bundle exec`?"
+require "rubygems"
+require "bundler/setup"
+
+while !system(Gem.bin_path("guard", "_guard-core"), *ARGV) && $?.exitstatus == 2
+  puts("Restarting guard...")
 end
-
-Guard::ArubaAdapter.new(ARGV.dup).execute!
+exit($?.exitstatus)

--- a/guard.gemspec
+++ b/guard.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |s|
     /^(?:bin|images|lib)\/.*$/ =~ f
   end + %w(CHANGELOG.md LICENSE man/guard.1 man/guard.1.html README.md)
 
-  s.executable   = "guard"
+  s.executables   = %w[guard _guard-core]
   s.require_path = "lib"
 end

--- a/lib/guard.rb
+++ b/lib/guard.rb
@@ -155,11 +155,7 @@ module Guard
       return if guardfiles.empty?
 
       if guardfiles.any? { |path| /^Guardfile$/.match(path) }
-        UI.warning <<EOS
-Guardfile changed - Guard will exit so you can restart it manually.
-
-More info here: https://github.com/guard/guard/wiki/Guard-2.10.3-exits-when-Guardfile-is-changed
-EOS
+        UI.warning "Guardfile changed -- _guard-core will exit.\n"
         exit 2 # nonzero to break any while loop
       else
         msg = "Config changed: %s - Guard will exit so it can be restarted."

--- a/lib/guard/internals/scope.rb
+++ b/lib/guard/internals/scope.rb
@@ -55,8 +55,10 @@ module Guard
 
       def titles(scope = nil)
         hash = scope || to_hash
-        return hash[:plugins].map(&:title) unless hash[:plugins].empty?
-        return hash[:groups].map(&:title) unless hash[:groups].empty?
+        plugins = hash[:plugins]
+        groups = hash[:groups]
+        return plugins.map(&:title) unless plugins.nil? || plugins.empty?
+        return hash[:groups].map(&:title) unless groups.nil? || groups.empty?
         ["all"]
       end
 

--- a/lib/guard/templates/Guardfile
+++ b/lib/guard/templates/Guardfile
@@ -14,8 +14,8 @@
 ##  $ while bundle exec guard; do echo "Restarting Guard..."; done
 ##
 ## Note: if you are using the `directories` clause above and you are not
-## watching the project directory ('.'), then you will want to move the Guardfile
-## to a watched dir and symlink it back, e.g.
+## watching the project directory ('.'), then you will want to move
+## the Guardfile to a watched dir and symlink it back, e.g.
 #
 #  $ mkdir config
 #  $ mv Guardfile config/


### PR DESCRIPTION
This uses the advertised solution but it integrates it into the gem.
`bin/guard` is now the wrapper and it and it the original guard is now
`bin/_guard-core`.

All parameters to the wrapper are passed down to `_guard-core` --> all
tests are green.

I think this is much better from the user's perspective.