### PR TITLE
Allow Guard to work without a Gemfile

### DIFF
--- a/bin/guard
+++ b/bin/guard
@@ -1,10 +1,16 @@
 #!/usr/bin/env ruby
 
-require "pathname"
-ENV["BUNDLE_GEMFILE"] ||= (Pathname(__FILE__).realpath + "../../Gemfile").to_s
-
-require "rubygems"
-require "bundler/setup"
+begin
+  require "pathname"
+  gemfile = Pathname(__FILE__).realpath + "../../Gemfile"
+  if gemfile.exist?
+    ENV["BUNDLE_GEMFILE"] ||= gemfile.to_s
+    require "rubygems"
+    require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+  else
+    require "rubygems"
+  end
+end
 
 while !system(Gem.bin_path("guard", "_guard-core"), *ARGV) && $?.exitstatus == 2
   puts("Restarting guard...")


### PR DESCRIPTION
This allows guard to be run using only RubyGems