### PR TITLE
Fix ignore_interrupts so that it doesn't break autoreloads

### DIFF
--- a/bin/guard
+++ b/bin/guard
@@ -22,6 +22,7 @@ def ignore_interrupts(*args)
   rescue Interrupt
     retry
   end
+  return $? == 0
 end
 
 guard_core_path = Gem.bin_path("guard", "_guard-core")


### PR DESCRIPTION
ignore_interrupts broke autoreloads because it didn't return the same
way `system` did (return $? == 0).

Basically:

When I start Guard
And run `touch Guardfile`
I expect a reload rather then an exit.

Don't know how to make proper feature spec out of this because of since this should start two _guard-core instances. 