### PR TITLE
Fixes Guardfile handling edge cases [fix 765]

### DIFF
--- a/features/init.feature
+++ b/features/init.feature
@@ -13,3 +13,11 @@ Feature: Guard "init" command
     When I run `guard init rspec`
     Then the output should match /Writing new Guardfile to .*Guardfile$/
     And the file "Guardfile" should match /^guard :rspec, cmd: ['"]bundle exec rspec["'] do$/
+
+  Scenario: Add plugin to when empty Guardfile exists
+    Given my Guardfile contains:
+    """
+    """
+    When I run `guard init rspec`
+    Then the output should match /rspec guard added to Guardfile, feel free to edit it$/
+    And the file "Guardfile" should match /^guard :rspec, cmd: ['"]bundle exec rspec["'] do$/

--- a/features/init.feature
+++ b/features/init.feature
@@ -21,3 +21,12 @@ Feature: Guard "init" command
     When I run `guard init rspec`
     Then the output should match /rspec guard added to Guardfile, feel free to edit it$/
     And the file "Guardfile" should match /^guard :rspec, cmd: ['"]bundle exec rspec["'] do$/
+
+  Scenario: Add plugin when Guardfile contains only options
+    Given my Guardfile contains:
+    """
+    notification :off
+    """
+    When I run `guard init rspec`
+    Then the output should match /rspec guard added to Guardfile, feel free to edit it$/
+    And the file "Guardfile" should match /^guard :rspec, cmd: ['"]bundle exec rspec["'] do$/

--- a/lib/guard/cli/environments/valid.rb
+++ b/lib/guard/cli/environments/valid.rb
@@ -34,13 +34,17 @@ module Guard
             Guardfile::Evaluator.new(session.evaluator_options).evaluate
           rescue Guardfile::Evaluator::NoGuardfileError
             generator.create_guardfile
+          rescue Guard::Guardfile::Evaluator::NoPluginsError
+            # Do nothing - just the error
           end
 
           return 0 if bare # 0 - exit code
 
           # Evaluate because it might have existed and creating was skipped
-          # FIXME: still, I don't know why this is needed
-          Guardfile::Evaluator.new(session.evaluator_options).evaluate
+          begin
+            Guardfile::Evaluator.new(session.evaluator_options).evaluate
+          rescue Guard::Guardfile::Evaluator::NoPluginsError
+          end
 
           if plugin_names.empty?
             generator.initialize_all_templates

--- a/lib/guard/dsl_reader.rb
+++ b/lib/guard/dsl_reader.rb
@@ -15,7 +15,7 @@ module Guard
     end
 
     # Stub everything else
-    def notification
+    def notification(_notifier, _opts = {})
     end
 
     def interactor(_options)

--- a/lib/guard/plugin_util.rb
+++ b/lib/guard/plugin_util.rb
@@ -129,7 +129,11 @@ module Guard
       # TODO: move this to Generator?
       options = Guard.state.session.evaluator_options
       evaluator = Guardfile::Evaluator.new(options)
-      evaluator.evaluate
+      begin
+        evaluator.evaluate
+      rescue Guard::Guardfile::Evaluator::NoPluginsError
+      end
+
       if evaluator.guardfile_include?(name)
         UI.info "Guardfile already includes #{ name } guard"
       else

--- a/spec/lib/guard/cli/environments/valid_spec.rb
+++ b/spec/lib/guard/cli/environments/valid_spec.rb
@@ -207,10 +207,26 @@ RSpec.describe Guard::Cli::Environments::Valid do
       end
 
       context "when passed a guard name" do
+        context "when the Guardfile is empty" do
+          before do
+            allow(evaluator).to receive(:evaluate).
+              and_raise Guard::Guardfile::Evaluator::NoPluginsError
+            allow(generator).to receive(:initialize_template)
+          end
+
+          it "works without without errors" do
+            expect(subject.initialize_guardfile(%w(rspec))).to be_zero
+          end
+
+          it "adds the template" do
+            expect(generator).to receive(:initialize_template).with("rspec")
+            subject.initialize_guardfile(%w(rspec))
+          end
+        end
+
         it "initializes the template of the passed Guard" do
           expect(generator).to receive(:initialize_template).with("rspec")
-
-          subject.initialize_guardfile(["rspec"])
+          subject.initialize_guardfile(%w(rspec))
         end
       end
 

--- a/spec/lib/guard/dsl_reader_spec.rb
+++ b/spec/lib/guard/dsl_reader_spec.rb
@@ -1,0 +1,38 @@
+require "guard/dsl_reader"
+
+RSpec.describe Guard::DslReader, exclude_stubs: [Guard::Dsl] do
+  methods = %w(
+    initialize guard notification interactor group watch callback
+    ignore ignore! logger scope directories clearing
+  ).map(&:to_sym)
+
+  methods.each do |meth|
+    describe "\##{meth} signature" do
+      it "matches base signature" do
+        expected = Guard::Dsl.instance_method(meth).arity
+        expect(subject.method(meth).arity).to eq(expected)
+      end
+    end
+  end
+
+  describe "guard" do
+    it "works without errors" do
+      expect { subject.guard("foo", bar: :baz) }.to_not raise_error
+    end
+  end
+
+  describe "plugin_names" do
+    it "returns encountered names" do
+      subject.guard("foo", bar: :baz)
+      subject.guard("bar", bar: :baz)
+      subject.guard("baz", bar: :baz)
+      expect(subject.plugin_names).to eq(%w(foo bar baz))
+    end
+  end
+
+  describe "notification" do
+    it "handles arguments without errors" do
+      expect { subject.notification(:off) }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
- allow `guard init` to add plugins to empty Guardfile

- fix parameters in DslReader to handle cases when Guardfile uses notification

(Fixes #765)