### PR TITLE
Modified the info about maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### :warning: Guard is [looking for new maintainers](https://groups.google.com/forum/#!topic/guard-dev/2Td0QTvTIsE). Please [contact me](mailto:thibaud@thibaud.gg) if you're interested.
+### :exclamation::exclamation: Guard is [currently accepting more maintainers/contributors](https://groups.google.com/forum/#!topic/guard-dev/2Td0QTvTIsE). Please [contact me](mailto:thibaud@thibaud.gg) or [Cezary Baginski](mailto:cezary@chronomantic.net) if you're interested in joining the team. :exclamation::exclamation:
 
 Guard
 =====


### PR DESCRIPTION
@thibaudgg , @rymai - I wanted to change the maintainer CTA notice a bit.

I don't want people to get the impression the project is abandoned (which is far from true) - and by doing so guard is less likely to find active maintainers or even contributors.

(The notice gives the impression the project is dead and that there are bugs with no one to fix them).

Ideas for better message would be great (same probably goes for the Listen project).