### PR TITLE
Why is usage of rubygems and bundler enforced?

### DIFF
--- a/bin/guard
+++ b/bin/guard
@@ -1,19 +1,5 @@
 #!/usr/bin/env ruby
 
-require "pathname"
-
-default = Pathname(ENV.fetch("BUNDLE_GEMFILE", "Gemfile"))
-relative_to_binstub = Pathname(__FILE__).realpath + "../../Gemfile"
-gemfile = [default, relative_to_binstub].detect(&:exist?)
-
-if gemfile && !ENV["RUBYGEMS_GEMDEPS"]
-  ENV["BUNDLE_GEMFILE"] = gemfile.to_s
-  require "rubygems"
-  require "bundler/setup"
-else
-  require "rubygems"
-end
-
 def ignore_interrupts(*args)
   args.unshift(RbConfig.ruby) if Gem.win_platform?
   pid = spawn(*args)

--- a/lib/guard.rb
+++ b/lib/guard.rb
@@ -1,5 +1,6 @@
 require "thread"
 require "listen"
+require "pathname"
 
 require "guard/config"
 require "guard/deprecated/guard" unless Guard::Config.new.strict?

--- a/lib/guard/guardfile/evaluator.rb
+++ b/lib/guard/guardfile/evaluator.rb
@@ -1,3 +1,5 @@
+require "pathname"
+
 require "guard/config"
 require "guard/deprecated/evaluator" unless Guard::Config.new.strict?
 

--- a/lib/guard/guardfile/generator.rb
+++ b/lib/guard/guardfile/generator.rb
@@ -1,3 +1,5 @@
+require "pathname"
+
 require "guard/ui"
 require "guard/plugin_util"
 

--- a/lib/guard/internals/helpers.rb
+++ b/lib/guard/internals/helpers.rb
@@ -1,3 +1,5 @@
+require "pathname"
+
 module Guard
   # @private api
   module Internals

--- a/lib/guard/jobs/pry_wrapper.rb
+++ b/lib/guard/jobs/pry_wrapper.rb
@@ -1,3 +1,5 @@
+require "pathname"
+
 require "guard/commands/all"
 require "guard/commands/change"
 require "guard/commands/notification"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@
 # users commonly want.
 #
 
+require "pathname"
 require "fileutils"
 
 require "codeclimate-test-reporter"


### PR DESCRIPTION
We are forced to use rubygems and if there is a Gemfile in the project, than we are forced to put guard in the Gemfile, but if guard is installed through rubygems, there will be a wrapper for guard bin which will require rubygems and `bundle exec guard` will require bundle.

In my case I would prefer not to add guard to bundler as I don't want an additional dependency in the app even development one and currently the only way is to set `RUBYGEMS_GEMDEPS` to something in bash/zsh init or to alias guard to `RUBYGEMS_GEMDEPS=- guard`.

I've also required pathname in files where it is used as the only `require "pathname"` is in `bin/guard`.