### PR TITLE
also trace spawn() calls when debugging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ group :test do
 
   gem "codeclimate-test-reporter", require: nil
   gem "rspec", ">= 3.0.0", require: false
-  gem "aruba", "~> 0.8", require: false
+  gem "aruba", "~> 0.9", require: false
   gem "notiffany", ">= 0.0.6", require: false
 end
 

--- a/features/init.feature
+++ b/features/init.feature
@@ -42,5 +42,6 @@ Feature: Guard "init" command
     """
     When I run `guard init rspec`
     And I run `guard init rspec`
-    Then the output should match /rspec guard added to Guardfile, feel free to edit it\n.*Guardfile already includes rspec guard$/
+    Then the output should match /rspec guard added to Guardfile, feel free to edit it/
+    And the output should match /.*Guardfile already includes rspec guard/
     And the file "Guardfile" should match /^guard :rspec, cmd: ['"]bundle exec rspec["'] do$/

--- a/features/step_definitions/guard_steps.rb
+++ b/features/step_definitions/guard_steps.rb
@@ -16,11 +16,11 @@ Given(/^Guard is bundled using source$/) do
 
   write_file("Gemfile", "#{gems.join("\n")}\n")
 
-  run_simple(Aruba::Platform.unescape("bundle install --quiet"), true)
+  run_simple("bundle install --quiet", true)
 end
 
 When(/^I start `([^`]*)`$/) do |cmd|
-  @interactive = run(Aruba::Platform.unescape(cmd))
+  @interactive = run(cmd)
   step "I wait for Guard to become idle"
 end
 
@@ -45,9 +45,9 @@ end
 When(/^I wait for Guard to become idle$/) do
   expected = "guard(main)>"
   begin
-    Timeout::timeout(exit_timeout) do
+    Timeout::timeout(aruba.config.exit_timeout) do
       loop do
-        break if assert_partial_output_interactive(expected)
+        break if last_command_started.stdout.include?(expected)
         sleep 0.1
       end
     end

--- a/lib/guard/internals/debugging.rb
+++ b/lib/guard/internals/debugging.rb
@@ -13,6 +13,7 @@ module Guard
       class << self
         TRACES = [
           [Kernel, :system],
+          [Kernel, :spawn],
           [Kernel, :`],
           [Open3, :popen3]
         ]

--- a/spec/lib/guard/internals/debugging_spec.rb
+++ b/spec/lib/guard/internals/debugging_spec.rb
@@ -44,6 +44,15 @@ RSpec.describe Guard::Internals::Debugging do
       described_class.start
     end
 
+    it "traces Kernel.spawn" do
+      expect(tracing).to receive(:trace).with(Kernel, :spawn) do |*_, &block|
+        expect(ui).to receive(:debug).with("Command execution: foo")
+        block.call("foo")
+      end
+
+      described_class.start
+    end
+
     context "when not started" do
       before { described_class.start }
 


### PR DESCRIPTION
Spawn() is used by Guard::RSpec