### PR TITLE
Fix #771, Guard now fails with the 1 exit code when plugin is not available

### DIFF
--- a/lib/guard/cli/environments/valid.rb
+++ b/lib/guard/cli/environments/valid.rb
@@ -54,7 +54,8 @@ module Guard
                 generator.initialize_template(plugin_name)
               end
             end
-          rescue Errno::ENOENT
+          rescue Guardfile::Generator::Error => e
+            UI.error(e.message)
             return 1
           end
 

--- a/lib/guard/cli/environments/valid.rb
+++ b/lib/guard/cli/environments/valid.rb
@@ -46,13 +46,18 @@ module Guard
           rescue Guard::Guardfile::Evaluator::NoPluginsError
           end
 
-          if plugin_names.empty?
-            generator.initialize_all_templates
-          else
-            plugin_names.each do |plugin_name|
-              generator.initialize_template(plugin_name)
+          begin
+            if plugin_names.empty?
+              generator.initialize_all_templates
+            else
+              plugin_names.each do |plugin_name|
+                generator.initialize_template(plugin_name)
+              end
             end
+          rescue Errno::ENOENT
+            return 1
           end
+
           # TODO: capture exceptions to show msg and return exit code on
           # failures
           0 # exit code

--- a/lib/guard/guardfile/generator.rb
+++ b/lib/guard/guardfile/generator.rb
@@ -87,13 +87,13 @@ module Guard
         _ui(:info, format(INFO_TEMPLATE_ADDED, plugin_name))
 
       rescue Errno::ENOENT => error
-
         name = plugin_name.downcase
         class_name = name.gsub("-", "").capitalize
         _ui(:error, "Could not load 'guard/#{name}'"\
             " or '~/.guard/templates/#{name}'"\
             " or find class Guard::#{class_name}")
         _ui(:error, "Error is: #{error}")
+        fail error
       end
 
       # Adds the templates of all installed Guard implementations to an

--- a/lib/guard/guardfile/generator.rb
+++ b/lib/guard/guardfile/generator.rb
@@ -38,6 +38,24 @@ module Guard
         HOME_TEMPLATES = Pathname("/").expand_path
       end
 
+      class Error < RuntimeError
+      end
+
+      class NoSuchPlugin < Error
+        attr_reader :plugin_name, :class_name
+
+        def initialize(plugin_name)
+          @plugin_name = plugin_name
+          @class_name = plugin_name.gsub("-", "").capitalize
+        end
+
+        def message
+          "Could not load 'guard/#{plugin_name}'"\
+          " or '~/.guard/templates/#{plugin_name}'"\
+          " or find class Guard::#{class_name}\n"
+        end
+      end
+
       # Creates the initial Guardfile template when it does not
       # already exist.
       #
@@ -86,14 +104,8 @@ module Guard
 
         _ui(:info, format(INFO_TEMPLATE_ADDED, plugin_name))
 
-      rescue Errno::ENOENT => error
-        name = plugin_name.downcase
-        class_name = name.gsub("-", "").capitalize
-        _ui(:error, "Could not load 'guard/#{name}'"\
-            " or '~/.guard/templates/#{name}'"\
-            " or find class Guard::#{class_name}")
-        _ui(:error, "Error is: #{error}")
-        fail error
+      rescue Errno::ENOENT
+        fail NoSuchPlugin, plugin_name.downcase
       end
 
       # Adds the templates of all installed Guard implementations to an

--- a/spec/lib/guard/cli/environments/valid_spec.rb
+++ b/spec/lib/guard/cli/environments/valid_spec.rb
@@ -231,8 +231,18 @@ RSpec.describe Guard::Cli::Environments::Valid do
       end
 
       it "returns an exit code" do
-        # TODO: ideally, we'd capture known exceptions and return nonzero
         expect(subject.initialize_guardfile).to be_zero
+      end
+
+      context "when passed an unknown guard name" do
+        before do
+          expect(generator).to receive(:initialize_template).with("foo").
+            and_raise(Errno::ENOENT)
+        end
+
+        it "returns an exit code" do
+          expect(subject.initialize_guardfile(%w(foo))).to be(1)
+        end
       end
     end
   end

--- a/spec/lib/guard/cli/environments/valid_spec.rb
+++ b/spec/lib/guard/cli/environments/valid_spec.rb
@@ -237,10 +237,14 @@ RSpec.describe Guard::Cli::Environments::Valid do
       context "when passed an unknown guard name" do
         before do
           expect(generator).to receive(:initialize_template).with("foo").
-            and_raise(Errno::ENOENT)
+            and_raise(Guard::Guardfile::Generator::NoSuchPlugin, "foo")
         end
 
         it "returns an exit code" do
+          expect(::Guard::UI).to receive(:error).with(
+            "Could not load 'guard/foo' or '~/.guard/templates/foo'"\
+            " or find class Guard::Foo\n"
+          )
           expect(subject.initialize_guardfile(%w(foo))).to be(1)
         end
       end

--- a/spec/lib/guard/guardfile/generator_spec.rb
+++ b/spec/lib/guard/guardfile/generator_spec.rb
@@ -117,16 +117,8 @@ RSpec.describe Guard::Guardfile::Generator do
       end
 
       it "notifies the user about the problem" do
-        expect(::Guard::UI).to receive(:error).with(
-          "Could not load 'guard/foo' or '~/.guard/templates/foo'"\
-          " or find class Guard::Foo"
-        )
-        expect(::Guard::UI).to receive(:error).with(
-          /Error is: No such file or directory/
-        )
-
         expect { described_class.new.initialize_template("foo") }.
-          to raise_error(Errno::ENOENT)
+          to raise_error(Guard::Guardfile::Generator::Error)
       end
     end
   end

--- a/spec/lib/guard/guardfile/generator_spec.rb
+++ b/spec/lib/guard/guardfile/generator_spec.rb
@@ -125,7 +125,8 @@ RSpec.describe Guard::Guardfile::Generator do
           /Error is: No such file or directory/
         )
 
-        described_class.new.initialize_template("foo")
+        expect { described_class.new.initialize_template("foo") }.
+          to raise_error(Errno::ENOENT)
       end
     end
   end


### PR DESCRIPTION
i.e. running 'bundle exec guard init rspec' with guard-rspec not
available will exit with the 1 exit code.

@e2 Is it an acceptable solution?