### PR TITLE
Key device is not symbol but a string.

### DIFF
--- a/lib/guard/ui.rb
+++ b/lib/guard/ui.rb
@@ -25,7 +25,7 @@ module Guard
         @logger ||= begin
                       require "lumberjack"
                       Lumberjack::Logger.new(
-                        options.fetch(:device) { $stderr },
+                        options.fetch('device') { $stderr },
                         options)
                     end
       end


### PR DESCRIPTION
I need log Guard messages to file. Argument :device of 'logger' method do not work as expected - log file is not created. After debug i realize bug in function Guard::Ui.logger

```ruby
      # Get the Guard::UI logger instance
      #
      def logger
        @logger ||= begin
                      require "lumberjack"
                      Lumberjack::Logger.new(
                        options.fetch(:device) { $stderr },
                        options)
                    end
      end
```

in options hash are all keys as string, not as symbols.