### PR TITLE
Fix misleading pause message

### DIFF
--- a/lib/guard/commander.rb
+++ b/lib/guard/commander.rb
@@ -92,7 +92,7 @@ module Guard
       return if pause == paused
 
       listener.public_send(pause ? :pause : :start)
-      UI.info "File modification listening is now #{pause.to_s.upcase}"
+      UI.info "File event handling has been #{pause ? 'paused' : 'resumed'}"
     end
 
     def show

--- a/spec/lib/guard/commander_spec.rb
+++ b/spec/lib/guard/commander_spec.rb
@@ -178,8 +178,18 @@ RSpec.describe Guard::Commander do
 
       [:toggle, nil, :paused].each do |mode|
         context "with #{mode.inspect}" do
+          before do
+            allow(listener).to receive(:pause)
+          end
+
           it "pauses" do
             expect(listener).to receive(:pause)
+            Guard.pause(mode)
+          end
+
+          it "shows a message" do
+            expected = /File event handling has been paused/
+            expect(Guard::UI).to receive(:info).with(expected)
             Guard.pause(mode)
           end
         end
@@ -212,8 +222,18 @@ RSpec.describe Guard::Commander do
 
       [:toggle, nil, :unpaused].each do |mode|
         context "with #{mode.inspect}" do
+          before do
+            allow(listener).to receive(:start)
+          end
+
           it "unpauses" do
             expect(listener).to receive(:start)
+            Guard.pause(mode)
+          end
+
+          it "shows a message" do
+            expected = /File event handling has been resumed/
+            expect(Guard::UI).to receive(:info).with(expected)
             Guard.pause(mode)
           end
         end


### PR DESCRIPTION
- state is now properly described
- describe pause in a less misleading way