### PR TITLE
Plumb the depths of the callstack

### DIFF
--- a/lib/guard/ui.rb
+++ b/lib/guard/ui.rb
@@ -204,8 +204,9 @@ module Guard
       # @return [String] the Guard plugin name
       #
       def calling_plugin_name(depth = 2)
-        name = %r{(guard\/[a-z_]*)(/[a-z_]*)?.rb:}i.match(caller[depth])
-        return "Guard" unless name
+        name = caller.take(depth).lazy.map do |line| 
+          %r{(?<!guard\/lib)\/(guard\/[a-z_]*)(/[a-z_]*)?.rb:}i.match(line)
+        end.reject(&:nil?).take(1).force
         name[1].split("/").map do |part|
           part.split(/[^a-z0-9]/i).map(&:capitalize).join
         end.join("::")

--- a/lib/guard/ui.rb
+++ b/lib/guard/ui.rb
@@ -204,7 +204,7 @@ module Guard
       # @return [String] the Guard plugin name
       #
       def calling_plugin_name(depth = 2)
-        name = caller.take(depth).lazy.map do |line| 
+        name = caller.take(depth).lazy.map do |line|
           %r{(?<!guard\/lib)\/(guard\/[a-z_]*)(/[a-z_]*)?.rb:}i.match(line)
         end.reject(&:nil?).take(1).force
         name[1].split("/").map do |part|

--- a/lib/guard/ui.rb
+++ b/lib/guard/ui.rb
@@ -207,6 +207,7 @@ module Guard
         name = caller.take(depth).lazy.map do |line|
           %r{(?<!guard\/lib)\/(guard\/[a-z_]*)(/[a-z_]*)?.rb:}i.match(line)
         end.reject(&:nil?).take(1).force
+        return "Guard" unless name or name == "guard/lib"
         name[1].split("/").map do |part|
           part.split(/[^a-z0-9]/i).map(&:capitalize).join
         end.join("::")


### PR DESCRIPTION
This is a variant implementation of `calling_plugin_name` that will actually run through the callstack up to the specified depth (instead of just checking the line in the callstack at that depth only).

It updates the regex with a negative lookbehind to make sure it isn't inside a Guard library file.

This doesn't fix the issue referred to in #849 but does make the existing code behave as probably intended, which is used in filtering plugin logs.