### PR TITLE
Fix default type on listen_to method_option for newer versions of Thor

### DIFF
--- a/lib/guard/cli.rb
+++ b/lib/guard/cli.rb
@@ -92,7 +92,7 @@ module Guard
     method_option :listen_on,
                   type: :string,
                   aliases: "-o",
-                  default: false,
+                  default: nil,
                   banner: "Specify a network address to Listen on for "\
                   "file change events (e.g. for use in VMs)"
 


### PR DESCRIPTION
Fixes #859 
