### PR TITLE
Fixes 858 - guard -c does not clear window buffer on OSX

### DIFF
--- a/lib/guard/terminal.rb
+++ b/lib/guard/terminal.rb
@@ -4,7 +4,7 @@ module Guard
   class Terminal
     class << self
       def clear
-        cmd = Gem.win_platform? ? "cls" : "clear;"
+        cmd = Gem.win_platform? ? "cls" : "printf '\33c\e[3J';"
         exit_code, _, stderr = Shellany::Sheller.system(cmd)
         fail Errno::ENOENT, stderr unless exit_code == 0
       end

--- a/spec/lib/guard/terminal_spec.rb
+++ b/spec/lib/guard/terminal_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe Guard::Terminal do
         let(:result) { [0, "\e[H\e[2J", ""] }
 
         it "clears the screen using 'clear'" do
-          expect(sheller).to receive(:system).with("clear;").and_return(result)
+          expect(sheller).to receive(:system).with("printf '\33c\e[3J';").
+            and_return(result)
           ::Guard::Terminal.clear
         end
       end
@@ -27,7 +28,8 @@ RSpec.describe Guard::Terminal do
         let(:result) { [nil, nil, "Guard failed to run \"clear;\""] }
 
         before do
-          allow(sheller).to receive(:system).with("clear;").and_return(result)
+          allow(sheller).to receive(:system).with("printf '\33c\e[3J';").
+            and_return(result)
         end
 
         it "fails" do


### PR DESCRIPTION
Fixes #858

Tested on OSX (macOS Sierra 10.12) and Ubuntu 12.04.5 LTS
