### PR TITLE
listen_on cli option should not have boolean default

### DIFF
--- a/lib/guard/cli.rb
+++ b/lib/guard/cli.rb
@@ -92,7 +92,6 @@ module Guard
     method_option :listen_on,
                   type: :string,
                   aliases: "-o",
-                  default: false,
                   banner: "Specify a network address to Listen on for "\
                   "file change events (e.g. for use in VMs)"
 


### PR DESCRIPTION
This is a string option, so it doesn't need a boolean default.  Thor has started validating the default type, and it's raising a warning here: https://github.com/erikhuda/thor/blob/v0.19.4/lib/thor/parser/option.rb#L131.