### PR TITLE
Execute the codeclimate-test-reporter bin as a separate CI step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ matrix:
   allow_failures:
     - rvm: rbx
     - rvm: jruby-9.0.5.0
+script:
+  - bundle exec rake
+  - bundle exec codeclimate-test-reporter
 sudo: false
 cache: bundler
 addons:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,8 +18,8 @@
 
 require "fileutils"
 
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
+require "simplecov"
+SimpleCov.start
 
 ENV["GUARD_SPECS_RUNNING"] = "1"
 


### PR DESCRIPTION
This should allow us to get rid of:

```
W, [2016-12-30T22:35:32.715873 #4325]  WARN -- :       This usage of the Code Climate Test Reporter is now deprecated. Since version
      1.0, we now require you to run `SimpleCov` in your test/spec helper, and then
      run the provided `codeclimate-test-reporter` binary separately to report your
      results to Code Climate.
      More information here: https://github.com/codeclimate/ruby-test-reporter/blob/master/README.md
```