### PR TITLE
Add aliasing section inside tired-of-typing bundle exec 

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ If you're getting sick of typing `bundle exec` all the time, try one of the foll
 * (Recommended) Running `bundle binstub guard` will create `bin/guard` in your
   project, which means running `bin/guard` (tab completion will save you a key
   stroke or two) will have the exact same result as `bundle exec guard`.
+  
+* Or, you can `alias be="bundle exec"` in your `.bashrc` or similar and the execute only `be guard`.
+  **Protip**: It will work for all comands executed in `bundle exec` context!  
+  
 
 * Or, for RubyGems >= 2.2.0 (at least, though the more recent the better),
   simply set the `RUBYGEMS_GEMDEPS` environment variable to `-` (for autodetecting


### PR DESCRIPTION
I think it's great to avoid typing `bundle exec <command>` having it aliased as `be <command>`