### PR TITLE
Travis: update CI matrix to include latest release of JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ rvm:
 matrix:
   allow_failures:
     - rvm: rbx-2
+env:
+  global:
+    - JRUBY_OPTS="--debug"
 script:
   - bundle exec rake
   - bundle exec codeclimate-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,18 @@
 language: ruby
-bundler_args: --without development
+sudo: false
 rvm:
   - 2.2.6
   - 2.3.3
   - 2.4.0
-  - jruby-9.0.5.0
-  - rbx
+  - jruby-9.1.13.0
+  - rbx-2
 matrix:
   allow_failures:
-    - rvm: rbx
-    - rvm: jruby-9.0.5.0
+    - rvm: rbx-2
 script:
   - bundle exec rake
   - bundle exec codeclimate-test-reporter
-sudo: false
+bundler_args: --without development
 cache: bundler
 addons:
   code_climate:


### PR DESCRIPTION
This PR updates the build matrix in Travis to:

- use `jruby-9.1.13.0`, latest release
- use `JRUBY_OPTS=--debug` to report coverage numbers
- place jruby-9.1.13.0 outside of `allowed_failures`
- use `rbx-2` - **Update**: [rbx-2 is the name, but it fails to install its deps](https://travis-ci.org/guard/guard/jobs/284112500)
- (Style change) order the settings in the YAML file.

I'll back out of any change if you folks don't like it.