### PR TITLE
Add `#==` method for `Guard::Watcher`

### DIFF
--- a/lib/guard/watcher.rb
+++ b/lib/guard/watcher.rb
@@ -26,6 +26,13 @@ module Guard
       @pattern = Pattern.create(pattern)
     end
 
+    # Compare with other watcher
+    # @param other [Guard::Watcher] other watcher for comparing
+    # @return [true, false] equal or not
+    def ==(other)
+      action == other.action && pattern == other.pattern
+    end
+
     # Finds the files that matches a Guard plugin.
     #
     # @param [Guard::Plugin] guard the Guard plugin which watchers are used

--- a/lib/guard/watcher/pattern/matcher.rb
+++ b/lib/guard/watcher/pattern/matcher.rb
@@ -2,8 +2,18 @@ module Guard
   class Watcher
     class Pattern
       class Matcher
+        attr_reader :matcher
+
         def initialize(obj)
           @matcher = obj
+        end
+
+        # Compare with other matcher
+        # @param other [Guard::Watcher::Pattern::Matcher]
+        #   other matcher for comparing
+        # @return [true, false] equal or not
+        def ==(other)
+          matcher == other.matcher
         end
 
         def match(string_or_pathname)

--- a/spec/lib/guard/watcher/pattern/matcher_spec.rb
+++ b/spec/lib/guard/watcher/pattern/matcher_spec.rb
@@ -42,6 +42,18 @@ RSpec.describe Guard::Watcher::Pattern::Matcher do
     end
   end
 
+  describe "#==" do
+    it "returns true for equal matchers" do
+      expect(described_class.new(/spec_helper\.rb/)).
+        to eq(described_class.new(/spec_helper\.rb/))
+    end
+
+    it "returns false for unequal matchers" do
+      expect(described_class.new(/spec_helper\.rb/)).
+        not_to eq(described_class.new(/spec_helper\.r/))
+    end
+  end
+
   describe "integration" do
     describe "#match result" do
       subject { described_class.new(obj).match(filename) }

--- a/spec/lib/guard/watcher_spec.rb
+++ b/spec/lib/guard/watcher_spec.rb
@@ -36,6 +36,18 @@ RSpec.describe Guard::Watcher do
     end
   end
 
+  describe "#==" do
+    it "returns true for equal watchers" do
+      expect(described_class.new(/spec_helper\.rb/)).
+        to eq(described_class.new(/spec_helper\.rb/))
+    end
+
+    it "returns false for unequal watchers" do
+      expect(described_class.new(/spec_helper\.rb/)).
+        not_to eq(described_class.new(/spec_helper\.r/))
+    end
+  end
+
   describe ".match_files" do
     let(:plugin) { instance_double("Guard::Plugin", options: {}) }
 


### PR DESCRIPTION
(and `Guard::Watcher::Pattern::Matcher`)

Simplify the testing `Guard::Plugin` with `Guard::Watcher` default options.