### PR TITLE
Fix: Correctly set logger options from Guardfile

### DIFF
--- a/features/logging.feature
+++ b/features/logging.feature
@@ -1,0 +1,64 @@
+Feature: setting logger options
+
+  In order to customize logging output
+  As a user
+  I want to specify the logger options
+
+  Background: Guard is installed through bundler
+    Given Guard is bundled using source
+
+  @spawn
+  Scenario: Customize logger template
+    Given my Guardfile contains:
+    """
+    require 'guard/plugin'
+
+    logger(template: '[Custom - :severity - :time - :progname] :message')
+
+    module ::Guard
+      class Myplugin < Plugin
+        def run_on_additions(files)
+          $stdout.puts "Files added: #{files.inspect}"
+          $stdout.flush
+        end
+      end
+    end
+
+    guard :myplugin do
+      watch('foo')
+    end
+
+    """
+    Given I start `bundle exec guard -n f`
+    And I create a file "foo"
+    And I wait for Guard to become idle
+    And I stop guard
+    Then the output should match /\[Custom - INFO - \d\d:\d\d:\d\d - Guard]/
+
+    @spawn
+    Scenario: Customize logger level
+      Given my Guardfile contains:
+      """
+      require 'guard/plugin'
+
+      logger(level: :warn)
+
+      module ::Guard
+        class Myplugin < Plugin
+          def run_on_additions(files)
+            $stdout.puts "Files added: #{files.inspect}"
+            $stdout.flush
+          end
+        end
+      end
+
+      guard :myplugin do
+        watch('foo')
+      end
+
+      """
+      Given I start `bundle exec guard -n f`
+      And I create a file "foo"
+      And I wait for Guard to become idle
+      And I stop guard
+      Then the output should not contain "INFO"

--- a/lib/guard/dsl.rb
+++ b/lib/guard/dsl.rb
@@ -349,7 +349,7 @@ module Guard
         options[name] = Regexp.new(list.join("|"), Regexp::IGNORECASE)
       end
 
-      UI.options.merge!(options)
+      UI.options = UI.options.merge(options)
     end
 
     # Sets the default scope on startup

--- a/spec/lib/guard/dsl_spec.rb
+++ b/spec/lib/guard/dsl_spec.rb
@@ -464,7 +464,7 @@ RSpec.describe Guard::Dsl do
 
   describe "#logger" do
     before do
-      allow(Guard::UI).to receive(:options).and_return( {} )
+      allow(Guard::UI).to receive(:options).and_return({})
       allow(Guard::UI).to receive(:options=)
     end
 
@@ -482,7 +482,7 @@ RSpec.describe Guard::Dsl do
         it { is_expected.to have_received(:options=).with(level: :error) }
       end
 
-     context "with logger level 'error'" do
+      context "with logger level 'error'" do
         let(:contents) { 'logger level: \'error\'' }
         it { is_expected.to have_received(:options=).with(level: :error) }
       end
@@ -490,8 +490,8 @@ RSpec.describe Guard::Dsl do
       context "with logger template" do
         let(:contents) { 'logger template: \':message - :severity\'' }
         it do
-          is_expected.to have_received(:options=)
-            .with(template: ":message - :severity")
+          is_expected.to have_received(:options=).
+            with(template: ":message - :severity")
         end
       end
 
@@ -570,7 +570,7 @@ RSpec.describe Guard::Dsl do
           expect(Guard::UI).to receive(:options=).with({})
           evaluator.call(contents)
         end
-     end
+      end
     end
   end
 

--- a/spec/lib/guard/dsl_spec.rb
+++ b/spec/lib/guard/dsl_spec.rb
@@ -464,13 +464,8 @@ RSpec.describe Guard::Dsl do
 
   describe "#logger" do
     before do
-      Guard::UI.options = nil
-      allow(ui_config).to receive(:merge!)
-    end
-
-    after do
-      Guard::UI.reset_logger
-      Guard::UI.options = nil
+      allow(Guard::UI).to receive(:options).and_return( {} )
+      allow(Guard::UI).to receive(:options=)
     end
 
     describe "options" do
@@ -480,63 +475,64 @@ RSpec.describe Guard::Dsl do
         evaluator.call(contents)
       end
 
-      subject { ui_config }
+      subject { Guard::UI }
 
-      context "with logger level :errror" do
+      context "with logger level :error" do
         let(:contents) { "logger level: :error" }
-        it { is_expected.to have_received(:merge!).with(level: :error) }
+        it { is_expected.to have_received(:options=).with(level: :error) }
       end
 
-      context "with logger level 'errror'" do
+     context "with logger level 'error'" do
         let(:contents) { 'logger level: \'error\'' }
-        it { is_expected.to have_received(:merge!).with(level: :error) }
+        it { is_expected.to have_received(:options=).with(level: :error) }
       end
 
       context "with logger template" do
         let(:contents) { 'logger template: \':message - :severity\'' }
         it do
-          is_expected.to have_received(:merge!).
-            with(template: ":message - :severity")
+          is_expected.to have_received(:options=)
+            .with(template: ":message - :severity")
         end
       end
 
       context "with a logger time format" do
         let(:contents) { 'logger time_format: \'%Y\'' }
-        it { is_expected.to have_received(:merge!).with(time_format: "%Y") }
+        it do
+          is_expected.to have_received(:options=).with(time_format: "%Y")
+        end
       end
 
       context "with a logger only filter from a symbol" do
         let(:contents) { "logger only: :cucumber" }
-        it { is_expected.to have_received(:merge!).with(only: /cucumber/i) }
+        it { is_expected.to have_received(:options=).with(only: /cucumber/i) }
       end
 
       context "with logger only filter from a string" do
         let(:contents) { 'logger only: \'jasmine\'' }
-        it { is_expected.to have_received(:merge!).with(only: /jasmine/i) }
+        it { is_expected.to have_received(:options=).with(only: /jasmine/i) }
       end
 
       context "with logger only filter from an array of symbols and string" do
         let(:contents) { 'logger only: [:rspec, \'cucumber\']' }
         it do
-          is_expected.to have_received(:merge!).
-            with(only: /rspec|cucumber/i)
+          is_expected.to have_received(:options=).with(only: /rspec|cucumber/i)
         end
       end
 
       context "with logger except filter from a symbol" do
         let(:contents) { "logger except: :jasmine" }
-        it { is_expected.to have_received(:merge!).with(except: /jasmine/i) }
+        it { is_expected.to have_received(:options=).with(except: /jasmine/i) }
       end
 
       context "with logger except filter from a string" do
         let(:contents) { 'logger except: \'jasmine\'' }
-        it { is_expected.to have_received(:merge!).with(except: /jasmine/i) }
+        it { is_expected.to have_received(:options=).with(except: /jasmine/i) }
       end
 
       context "with logger except filter from array of symbols and string" do
         let(:contents) { 'logger except: [:rspec, \'cucumber\', :jasmine]' }
         it do
-          is_expected.to have_received(:merge!).
+          is_expected.to have_received(:options=).
             with(except: /rspec|cucumber|jasmine/i)
         end
       end
@@ -555,7 +551,7 @@ RSpec.describe Guard::Dsl do
         end
 
         it "does not set the invalid value" do
-          expect(ui_config).to receive(:merge!).with({})
+          expect(Guard::UI).to receive(:options=).with({})
           evaluator.call(contents)
         end
       end
@@ -571,10 +567,10 @@ RSpec.describe Guard::Dsl do
         end
 
         it "removes the options" do
-          expect(ui_config).to receive(:merge!).with({})
+          expect(Guard::UI).to receive(:options=).with({})
           evaluator.call(contents)
         end
-      end
+     end
     end
   end
 


### PR DESCRIPTION
The Guard::Dsl#logger method is ignoring the user provided options. This branch fixes that, so that [the instructions provided in the Guard wiki](https://github.com/guard/guard/wiki/Guardfile-DSL---Configuring-Guard#logger) are accurate again.

The fix is just a single line change but I wanted to add some tests to make sure it's working properly.

See also #852.

PS: Credits to @christhekeele for pointing out the source of the problem in #852.