### PR TITLE
Fix rspec warning message.

### DIFF
--- a/spec/lib/guard/dsl_describer_spec.rb
+++ b/spec/lib/guard/dsl_describer_spec.rb
@@ -138,11 +138,11 @@ RSpec.describe Guard::DslDescriber do
         terminal_title: ::Notiffany::Notifier::TerminalTitle
       )
 
-      allow(Guard::Notifier).to receive(:connect).once.ordered
+      allow(Guard::Notifier).to receive(:connect).once
       allow(Guard::Notifier).to receive(:detected).
         and_return([{ name: :gntp, options: { sticky: true } }])
 
-      allow(Guard::Notifier).to receive(:disconnect).once.ordered
+      allow(Guard::Notifier).to receive(:disconnect).once
     end
 
     it "properly connects and disconnects" do


### PR DESCRIPTION
While testing with rspec, I found following warning:
~~~
$ rspec -rspec_helper spec
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 24497
................................................................*......................................................................................*................................................................................................................................................................................................................................................................................................................WARNING: `allow(...).to receive(..).ordered` is not supported and will have no effect, use `and_return(*ordered_values)` instead.. Called from /builddir/build/BUILD/guard-2.14.2/usr/share/gems/gems/guard-2.14.2/spec/lib/guard/dsl_describer_spec.rb:141:in `block (3 levels) in <top (required)>'.
WARNING: `allow(...).to receive(..).ordered` is not supported and will have no effect, use `and_return(*ordered_values)` instead.. Called from /builddir/build/BUILD/guard-2.14.2/usr/share/gems/gems/guard-2.14.2/spec/lib/guard/dsl_describer_spec.rb:145:in `block (3 levels) in <top (required)>'.
.WARNING: `allow(...).to receive(..).ordered` is not supported and will have no effect, use `and_return(*ordered_values)` instead.. Called from /builddir/build/BUILD/guard-2.14.2/usr/share/gems/gems/guard-2.14.2/spec/lib/guard/dsl_describer_spec.rb:141:in `block (3 levels) in <top (required)>'.
WARNING: `allow(...).to receive(..).ordered` is not supported and will have no effect, use `and_return(*ordered_values)` instead.. Called from /builddir/build/BUILD/guard-2.14.2/usr/share/gems/gems/guard-2.14.2/spec/lib/guard/dsl_describer_spec.rb:145:in `block (3 levels) in <top (required)>'.
.....................................................................................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Guard#relevant_changes? 
     # Not yet implemented
     # ./spec/lib/guard_spec.rb:245

  2) Guard::Internals::Scope#titles 
     # Not yet implemented
     # ./spec/lib/guard/internals/scope_spec.rb:91


Finished in 28.63 seconds (files took 0.94289 seconds to load)
613 examples, 0 failures, 2 pending

Randomized with seed 24497
~~~
Attached patch fixes the warning.
  