### PR TITLE
Fix rspec random test failure.

### DIFF
--- a/spec/lib/guard/plugin_util_spec.rb
+++ b/spec/lib/guard/plugin_util_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Guard::PluginUtil do
       gem = class_double(Gem::Specification)
       stub_const("Gem::Specification", gem)
       expect(Gem::Specification).to receive(:find_all) { gems }
+      allow(Gem::Specification).to receive(:unresolved_deps) { [] }
     end
 
     it "returns the list of guard gems" do


### PR DESCRIPTION
While testing with rspec, I found following errors:
~~~
$ rspec -rspec_helper --seed 50224
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 50224
...............................................WARNING: `allow(...).to receive(..).ordered` is not supported and will have no effect, use `and_return(*ordered_values)` instead.. Called from /builddir/build/BUILD/guard-2.14.2/usr/share/gems/gems/guard-2.14.2/spec/lib/guard/dsl_describer_spec.rb:141:in `block (3 levels) in <top (required)>'.
WARNING: `allow(...).to receive(..).ordered` is not supported and will have no effect, use `and_return(*ordered_values)` instead.. Called from /builddir/build/BUILD/guard-2.14.2/usr/share/gems/gems/guard-2.14.2/spec/lib/guard/dsl_describer_spec.rb:145:in `block (3 levels) in <top (required)>'.
.WARNING: `allow(...).to receive(..).ordered` is not supported and will have no effect, use `and_return(*ordered_values)` instead.. Called from /builddir/build/BUILD/guard-2.14.2/usr/share/gems/gems/guard-2.14.2/spec/lib/guard/dsl_describer_spec.rb:141:in `block (3 levels) in <top (required)>'.
WARNING: `allow(...).to receive(..).ordered` is not supported and will have no effect, use `and_return(*ordered_values)` instead.. Called from /builddir/build/BUILD/guard-2.14.2/usr/share/gems/gems/guard-2.14.2/spec/lib/guard/dsl_describer_spec.rb:145:in `block (3 levels) in <top (required)>'.
........................FFF................................................................................................................*......................*.....................................................................................................................................................................................................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Guard#relevant_changes? 
     # Not yet implemented
     # ./spec/lib/guard_spec.rb:245

  2) Guard::Internals::Scope#titles 
     # Not yet implemented
     # ./spec/lib/guard/internals/scope_spec.rb:91


Failures:

  1) Guard::PluginUtil.plugin_names returns the list of guard gems
     Failure/Error: expect(described_class.plugin_names).to include("myplugin")
       #<ClassDouble(Gem::Specification) (anonymous)> received unexpected message :unresolved_deps with (no args)
     # ./spec/lib/guard/plugin_util_spec.rb:40:in `block (3 levels) in <top (required)>'

  2) Guard::PluginUtil.plugin_names ignores guard-compat
     Failure/Error: expect(described_class.plugin_names).to_not include("compat")
       #<ClassDouble(Gem::Specification) (anonymous)> received unexpected message :unresolved_deps with (no args)
     # ./spec/lib/guard/plugin_util_spec.rb:48:in `block (3 levels) in <top (required)>'

  3) Guard::PluginUtil.plugin_names returns the list of embedded guard gems
     Failure/Error: expect(described_class.plugin_names).to include("gem2")
       #<ClassDouble(Gem::Specification) (anonymous)> received unexpected message :unresolved_deps with (no args)
     # ./spec/lib/guard/plugin_util_spec.rb:44:in `block (3 levels) in <top (required)>'

Finished in 32 seconds (files took 1.09 seconds to load)
613 examples, 3 failures, 2 pending

Failed examples:

rspec ./spec/lib/guard/plugin_util_spec.rb:39 # Guard::PluginUtil.plugin_names returns the list of guard gems
rspec ./spec/lib/guard/plugin_util_spec.rb:47 # Guard::PluginUtil.plugin_names ignores guard-compat
rspec ./spec/lib/guard/plugin_util_spec.rb:43 # Guard::PluginUtil.plugin_names returns the list of embedded guard gems

Randomized with seed 50224
~~~
The failures are happening on only on some seeds. Attached patch fixes listed failures.