### PR TITLE
add simplecov filter for a spec folder

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,9 @@
 require "fileutils"
 
 require "simplecov"
-SimpleCov.start
+SimpleCov.start do
+  add_filter "/spec"
+end
 
 ENV["GUARD_SPECS_RUNNING"] = "1"
 


### PR DESCRIPTION
it seems like there is no point to cover spec folder