### PR TITLE
Stub File.read instead of IO.read in spec.

### DIFF
--- a/spec/lib/guard/guardfile/generator_spec.rb
+++ b/spec/lib/guard/guardfile/generator_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Guard::Guardfile::Generator do
       let(:template) { File.join(described_class::HOME_TEMPLATES, "/bar") }
 
       it "copies the Guardfile template and initializes the Guard" do
-        expect(IO).to receive(:read)
+        expect(File).to receive(:read)
           .with(template).and_return "Template content"
 
         expected = "\nTemplate content\n"
@@ -113,7 +113,7 @@ RSpec.describe Guard::Guardfile::Generator do
         expect(::Guard::PluginUtil).to receive(:new) { plugin_util }
         allow(plugin_util).to receive(:plugin_class) { nil }
         path = File.expand_path("~/.guard/templates/foo")
-        expect(IO).to receive(:read).with(path) do
+        expect(File).to receive(:read).with(path) do
           fail Errno::ENOENT
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,14 +70,14 @@ def stub_file(path, contents = nil, &block)
   allow(File).to receive(:exist?).with(path).and_return(exists)
   if exists
     if block.nil?
-      allow(IO).to receive(:read).with(path).and_return(contents)
+      allow(File).to receive(:read).with(path).and_return(contents)
     else
-      allow(IO).to receive(:read).with(path) do
+      allow(File).to receive(:read).with(path) do
         yield
       end
     end
   else
-    allow(IO).to receive(:read).with(path) do
+    allow(File).to receive(:read).with(path) do
       fail Errno::ENOENT
     end
   end


### PR DESCRIPTION
Ruby 2.6 quietly changed Pathname#read from using IO.read to File.read, therefore approximately 6 tests fail with "stub me!" error.
Although this fixes the problem in 2.6, there will be failures in Ruby versions prior to the 2.6 with the current approach, the attached patch is a bit naive, I'd love to hear suggestions about how to go about this e.g. should there be Ruby version check or maybe someone has more elegant solutions?

relevant Ruby commit: https://github.com/ruby/ruby/commit/53a5b276b8bc6e22a9fecc23dd99259e2d0e7fa4