### PR TITLE
Fix YARD annotation

### DIFF
--- a/lib/guard/dsl.rb
+++ b/lib/guard/dsl.rb
@@ -68,7 +68,7 @@ module Guard
     #   notification :ruby_gntp, host: '192.168.1.5'
     #
     # @param [Symbol, String] notifier the name of the notifier to use
-    # @param [Hash] options the notification library options
+    # @param [Hash] opts the notification library options
     #
     # @see Guard::Notifier for available notifier and its options.
     #
@@ -366,7 +366,7 @@ module Guard
     # @example Scope Guard to multiple plugins
     #   scope plugins: [:jasmine, :rspec]
     #
-    # @param [Hash] scopes the scope for the groups and plugins
+    # @param [Hash] scope the scope for the groups and plugins
     #
     def scope(scope = {})
       # TODO: use a Guardfile::Results class

--- a/lib/guard/runner.rb
+++ b/lib/guard/runner.rb
@@ -11,7 +11,7 @@ module Guard
     #
     # @param [Symbol] task the task to run
     #
-    # @param [Hash] scopes either the Guard plugin or the group to run the task
+    # @param [Hash] scope_hash either the Guard plugin or the group to run the task
     # on
     #
     def run(task, scope_hash = {})
@@ -70,7 +70,7 @@ module Guard
     # When the Group has `:halt_on_fail` disabled, we've to catch
     # `:task_has_failed` here in order to avoid an uncaught throw error.
     #
-    # @param [Guard::Plugin] guard the Guard to execute
+    # @param [Guard::Plugin] plugin guard the Guard to execute
     # @param [Symbol] task the task to run
     # @param [Array] args the arguments for the task
     # @raise [:task_has_failed] when task has failed


### PR DESCRIPTION
This PR fixes YARD warnings.

 - Avoid warnings like: `[UnknownParam] @param tag has unknown parameter name: options`