### PR TITLE
CI: Use 2.4.6, 2.5.5, 2.6.2...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: ruby
-sudo: false
 rvm:
   - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.1
-  - jruby-9.1.15.0
-  - rbx-2
+  - 2.4.6
+  - 2.5.5
+  - 2.6.2
+  - jruby-9.1.17.0
+  - jruby-9.2.6.0
+  - rbx-3.107
 matrix:
   allow_failures:
-    - rvm: rbx-2
+    - rvm: rbx-3.107
 env:
   global:
     - JRUBY_OPTS="--debug"


### PR DESCRIPTION
   - jruby-9.1.17.0, jruby-9.2.6.0
  - rbx-3.107

Also: See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration for historical detail about when `sudo: false` was removed.

