### PR TITLE
 Stub Pathname instead of IO.read in spec

### DIFF
--- a/lib/guard/guardfile/evaluator.rb
+++ b/lib/guard/guardfile/evaluator.rb
@@ -60,7 +60,7 @@ module Guard
           @contents = opts[:contents]
         elsif opts[:guardfile]
           @type = :custom
-          @path = Pathname(opts[:guardfile]) # may be updated by _read
+          @path = Pathname.new(opts[:guardfile]) # may be updated by _read
         end
       end
 
@@ -190,7 +190,7 @@ module Guard
       end
 
       def _read(path)
-        full_path = Pathname(path).expand_path
+        full_path = Pathname.new(path.to_s).expand_path
         [full_path, full_path.read]
       rescue Errno::ENOENT
         fail
@@ -202,7 +202,7 @@ module Guard
       end
 
       def _guardfile_contents
-        @user_config ||= Pathname("~/.guard.rb").expand_path.read
+        @user_config ||= Pathname.new("~/.guard.rb").expand_path.read
         [@contents, @user_config].compact.join("\n")
       rescue Errno::ENOENT
         @contents || ""

--- a/lib/guard/guardfile/generator.rb
+++ b/lib/guard/guardfile/generator.rb
@@ -32,11 +32,11 @@ module Guard
 
       # The location of user defined templates
       begin
-        HOME_TEMPLATES = Pathname("~/.guard/templates").expand_path
+        HOME_TEMPLATES = Pathname.new("~/.guard/templates").expand_path
       rescue ArgumentError
         # home isn't defined.  Set to the root of the drive.  Trust that there
         # won't be user defined templates there
-        HOME_TEMPLATES = Pathname("/").expand_path
+        HOME_TEMPLATES = Pathname.new("/").expand_path
       end
 
       class Error < RuntimeError
@@ -63,7 +63,7 @@ module Guard
       # @see Guard::CLI#init
       #
       def create_guardfile
-        path = Pathname("Guardfile").expand_path
+        path = Pathname.new("Guardfile").expand_path
         if path.exist?
           _ui(:error, "Guardfile already exists at #{path}")
           abort
@@ -81,7 +81,7 @@ module Guard
       #   initialize
       #
       def initialize_template(plugin_name)
-        guardfile = Pathname("Guardfile")
+        guardfile = Pathname.new("Guardfile")
 
         plugin_util = PluginUtil.new(plugin_name)
         # TODO: change to "valid?" method

--- a/spec/lib/guard/guardfile/evaluator_spec.rb
+++ b/spec/lib/guard/guardfile/evaluator_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe Guard::Guardfile::Evaluator do
   let(:options) { {} }
   subject { described_class.new(options) }
 
-  let!(:local_guardfile) { (Pathname.pwd + "Guardfile").to_s }
-  let!(:home_guardfile) { (Pathname("~").expand_path + ".Guardfile").to_s }
-  let!(:home_config) { (Pathname("~").expand_path + ".guard.rb").to_s }
+  let!(:local_guardfile) { Pathname("Guardfile").to_s }
+  let!(:home_guardfile) { Pathname("~/.Guardfile").expand_path.to_s }
+  let!(:home_config) { Pathname("~/.guard.rb").expand_path.to_s }
 
   let(:valid_guardfile_string) { "group :foo; do guard :bar; end; end; " }
 
@@ -25,6 +25,7 @@ RSpec.describe Guard::Guardfile::Evaluator do
     allow(Guard::Interactor).to receive(:new).with(false)
     allow(Guard::Dsl).to receive(:new).and_return(dsl)
     allow(dsl).to receive(:instance_eval)
+    stub_pathname
   end
 
   describe ".evaluate" do
@@ -168,8 +169,13 @@ RSpec.describe Guard::Guardfile::Evaluator do
       subject.evaluate
     end
 
-    context "when content is provided" do
+    context "when guardfile_contents is provided" do
       let(:options) { { guardfile_contents: "guard :foo" } }
+      it { is_expected.to be_inline }
+    end
+
+    context "when contents is provided" do
+      let(:options) { { contents: "guard :foo" } }
       it { is_expected.to be_inline }
     end
 

--- a/spec/lib/guard/guardfile/generator_spec.rb
+++ b/spec/lib/guard/guardfile/generator_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe Guard::Guardfile::Generator do
   let(:plugin_util) { instance_double("Guard::PluginUtil") }
   let(:guardfile_generator) { described_class.new }
 
+  before do
+    stub_pathname
+  end
+
   it "has a valid Guardfile template" do
     allow(File).to receive(:exist?)
       .with(described_class::GUARDFILE_TEMPLATE).and_call_original
@@ -16,7 +20,7 @@ RSpec.describe Guard::Guardfile::Generator do
   describe "#create_guardfile" do
     context "with an existing Guardfile" do
       before do
-        allow_any_instance_of(Pathname).to receive(:exist?).and_return(true)
+        stub_guardfile("foo")
       end
 
       it "does not copy the Guardfile template or notify the user" do
@@ -38,7 +42,7 @@ RSpec.describe Guard::Guardfile::Generator do
 
       it "displays an error message" do
         expect(::Guard::UI).to receive(:error)
-          .with(%r{Guardfile already exists at .*/Guardfile})
+          .with("Guardfile already exists at Guardfile")
         begin
           subject.create_guardfile
         rescue SystemExit
@@ -52,13 +56,14 @@ RSpec.describe Guard::Guardfile::Generator do
 
     context "without an existing Guardfile" do
       before do
-        allow_any_instance_of(Pathname).to receive(:exist?).and_return(false)
+        stub_guardfile
         allow(FileUtils).to receive(:cp)
       end
 
       it "does not display any kind of error or abort" do
         expect(::Guard::UI).to_not receive(:error)
         expect(described_class).to_not receive(:abort)
+
         described_class.new.create_guardfile
       end
 
@@ -72,10 +77,13 @@ RSpec.describe Guard::Guardfile::Generator do
   end
 
   describe "#initialize_template" do
+    before do
+      @guardfile = stub_guardfile
+    end
+
     context "with an installed Guard implementation" do
       before do
         expect(Guard::PluginUtil).to receive(:new) { plugin_util }
-
         expect(plugin_util).to receive(:plugin_class) do
           double("Guard::Foo").as_null_object
         end
@@ -89,19 +97,18 @@ RSpec.describe Guard::Guardfile::Generator do
 
     context "with a user defined template" do
       let(:template) { File.join(described_class::HOME_TEMPLATES, "/bar") }
+      let(:template_content) { "Template content" }
+
+      before do
+        stub_file("bar")
+        stub_file(File.expand_path("~/.guard/templates/bar"), "Template content")
+      end
 
       it "copies the Guardfile template and initializes the Guard" do
-        expect(File).to receive(:read)
-          .with(template).and_return "Template content"
-
-        expected = "\nTemplate content\n"
-
-        expect(IO).to receive(:binwrite)
-          .with("Guardfile", expected, open_args: ["a"])
-
-        allow(plugin_util).to receive(:plugin_class).with(fail_gracefully: true)
-
-        allow(Guard::PluginUtil).to receive(:new).with("bar")
+        expect(@guardfile).to receive(:binwrite)
+          .with("\n#{template_content}\n", open_args: ["a"])
+        expect(plugin_util).to receive(:plugin_class).with(fail_gracefully: true)
+        expect(Guard::PluginUtil).to receive(:new).with("bar")
                                                  .and_return(plugin_util)
 
         described_class.new.initialize_template("bar")
@@ -112,10 +119,8 @@ RSpec.describe Guard::Guardfile::Generator do
       before do
         expect(::Guard::PluginUtil).to receive(:new) { plugin_util }
         allow(plugin_util).to receive(:plugin_class) { nil }
-        path = File.expand_path("~/.guard/templates/foo")
-        expect(File).to receive(:read).with(path) do
-          fail Errno::ENOENT
-        end
+        stub_file("foo")
+        stub_file(File.expand_path("~/.guard/templates/foo"))
       end
 
       it "notifies the user about the problem" do

--- a/spec/lib/guard/guardfile/generator_spec.rb
+++ b/spec/lib/guard/guardfile/generator_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Guard::Guardfile::Generator do
       let(:template) { File.join(described_class::HOME_TEMPLATES, "/bar") }
 
       it "copies the Guardfile template and initializes the Guard" do
-        expect(IO).to receive(:read)
+        expect(File).to receive(:read)
           .with(template).and_return "Template content"
 
         expected = "\nTemplate content\n"
@@ -113,7 +113,7 @@ RSpec.describe Guard::Guardfile::Generator do
         expect(::Guard::PluginUtil).to receive(:new) { plugin_util }
         allow(plugin_util).to receive(:plugin_class) { nil }
         path = File.expand_path("~/.guard/templates/foo")
-        expect(IO).to receive(:read).with(path) do
+        expect(File).to receive(:read).with(path) do
           fail Errno::ENOENT
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,14 +70,14 @@ def stub_file(path, contents = nil, &block)
   allow(File).to receive(:exist?).with(path).and_return(exists)
   if exists
     if block.nil?
-      allow(IO).to receive(:read).with(path).and_return(contents)
+      allow(File).to receive(:read).with(path).and_return(contents)
     else
-      allow(IO).to receive(:read).with(path) do
+      allow(File).to receive(:read).with(path) do
         yield
       end
     end
   else
-    allow(IO).to receive(:read).with(path) do
+    allow(File).to receive(:read).with(path) do
       fail Errno::ENOENT
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,20 +30,27 @@ Dir[path].each { |f| require f }
 
 # TODO: these shouldn't be necessary with proper specs
 
+def stub_pathname
+  allow(Pathname).to receive(:new).with(anything) do |*args, &_block|
+    caller.each { |l| puts l }
+    abort "stub me! (Pathname.new(#{args.map(&:inspect) * ', '}))"
+  end
+end
+
 def stub_guardfile(contents = nil, &block)
-  stub_file(File.expand_path("Guardfile"), contents, &block)
+  stub_file("Guardfile", contents, &block)
 end
 
 def stub_user_guardfile(contents = nil, &block)
-  stub_file(File.expand_path("~/.Guardfile"), contents, &block)
+  stub_file("~/.Guardfile", contents, &block)
 end
 
 def stub_user_guard_rb(contents = nil, &block)
-  stub_file(File.expand_path("~/.guard.rb"), contents, &block)
+  stub_file("~/.guard.rb", contents, &block)
 end
 
 def stub_user_project_guardfile(contents = nil, &block)
-  stub_file(File.expand_path(".Guardfile"), contents, &block)
+  stub_file(".Guardfile", contents, &block)
 end
 
 def stub_mod(mod, excluded)
@@ -67,20 +74,29 @@ end
 
 def stub_file(path, contents = nil, &block)
   exists = !contents.nil?
-  allow(File).to receive(:exist?).with(path).and_return(exists)
+
+  pathname = instance_double(Pathname)
+  allow(Pathname).to receive(:new).with(path).and_return(pathname)
+
+  allow(pathname).to receive(:to_s).and_return(path)
+  allow(pathname).to receive(:expand_path).and_return(pathname)
+  allow(pathname).to receive(:exist?).and_return(exists)
+
   if exists
     if block.nil?
-      allow(File).to receive(:read).with(path).and_return(contents)
+      allow(pathname).to receive(:read).and_return(contents)
     else
-      allow(File).to receive(:read).with(path) do
+      allow(pathname).to receive(:read) do
         yield
       end
     end
   else
-    allow(File).to receive(:read).with(path) do
+    allow(pathname).to receive(:read) do
       fail Errno::ENOENT
     end
   end
+
+  pathname
 end
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration


### PR DESCRIPTION
Reopening of https://github.com/guard/guard/pull/923.

Ruby 2.6 quietly changed `Pathname#read` from using `IO.read` to `File.read`, therefore approximately 6 tests fail with "stub me!" errors.

This fixes the problem by stubbing Pathname and some of its methods instead of stubbing underlying methods used by `Pathname#read` internally.

Relevant Ruby commit: ruby/ruby@53a5b27