### PR TITLE
Relax guard's thor dependency

### DIFF
--- a/guard.gemspec
+++ b/guard.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 1.9.3"
 
-  s.add_runtime_dependency "thor", ">= 0.18.1"
+  s.add_runtime_dependency "thor", ">= 0.18.1", "< 2.0"
   s.add_runtime_dependency "listen", ">= 2.7", "< 4.0"
   s.add_runtime_dependency "pry", ">= 0.9.12"
   s.add_runtime_dependency "lumberjack", ">= 1.0.12", "< 2.0"


### PR DESCRIPTION
I used < 2.0 because that's what Rails uses. Happy to make the high end more strict as long as we can support 0.20+. Thanks!

---

Rails 6.0 Railties requires thor set to
s.add_dependency "thor", ">= 0.20.3", "< 2.0" and currently guard
won't allow anything higher than 0.18.x. See
https://github.com/rails/rails/blob/master/railties/railties.gemspec#L40

This PR relaxes the thor dependency so that guard can be used with
applications running or upgrading to Rails 6+.