### PR TITLE
Cleanup guard process anytime

### DIFF
--- a/lib/guard/commander.rb
+++ b/lib/guard/commander.rb
@@ -47,8 +47,9 @@ module Guard
         exitcode = e.status
       end
 
-      stop
       exitcode
+    ensure
+      stop
     end
 
     def stop

--- a/lib/guard/notifier.rb
+++ b/lib/guard/notifier.rb
@@ -16,7 +16,7 @@ module Guard
     end
 
     def self.disconnect
-      @notifier.disconnect
+      @notifier && @notifier.disconnect
       @notifier = nil
     end
 

--- a/spec/lib/guard/commander_spec.rb
+++ b/spec/lib/guard/commander_spec.rb
@@ -82,6 +82,20 @@ RSpec.describe Guard::Commander do
         Guard.start
       end
     end
+
+    context "when listener.start raises an error" do
+      it "calls Commander#stop" do
+        allow(listener).to receive(:start).and_raise(RuntimeError)
+
+        # From stop()
+        expect(interactor).to receive(:background)
+        expect(listener).to receive(:stop)
+        expect(runner).to receive(:run).with(:stop)
+        expect(Guard::UI).to receive(:info).with("Bye bye...", reset: true)
+
+        expect { Guard.start }.to raise_error(RuntimeError)
+      end
+    end
   end
 
   describe ".stop" do


### PR DESCRIPTION
Problem
===


When guard raises an error, it does not clean up itself.
`Guard::Commander#stop` method is called only if the process stops successfully or it receives a signal.
So it is not called if guard raises an unexpected error.



Solution
===

Call `stop` method always.




The real problem in my case
=== 


I use [guard-process](https://github.com/guard/guard-process).
It executes a process, and kill the process via `stop` method. So if `stop` method is not called, the process will be a zombie. 


Guard raises an error and exits without calling `stop` method if the watched directory contains an unpermitted directory. 

Reproducing process:

```ruby
# Guardfile
guard 'process', :command => 'sleep 1m' do
  watch(%r!foo/.+!)
end
```

```console
$ mkdir -p foo/bar
# An ordinary user cannot read foo/bar directory.
$ chmod 700 foo/bar
$ sudo chown root:root foo/bar

# It fails
$ guard
18:11:12 - INFO - Starting process process
18:11:12 - INFO - Started process process
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rb-inotify-0.10.0/lib/rb-inotify/notifier.rb:194:in `initialize': Permission denied @ dir_initialize - /tmp/tmp.LDQdJwuRT4/foo/bar (Errno::EACCES)
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rb-inotify-0.10.0/lib/rb-inotify/notifier.rb:194:in `new'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rb-inotify-0.10.0/lib/rb-inotify/notifier.rb:194:in `watch'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rb-inotify-0.10.0/lib/rb-inotify/notifier.rb:204:in `block in watch'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rb-inotify-0.10.0/lib/rb-inotify/notifier.rb:196:in `each'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rb-inotify-0.10.0/lib/rb-inotify/notifier.rb:196:in `watch'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rb-inotify-0.10.0/lib/rb-inotify/notifier.rb:204:in `block in watch'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rb-inotify-0.10.0/lib/rb-inotify/notifier.rb:196:in `each'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rb-inotify-0.10.0/lib/rb-inotify/notifier.rb:196:in `watch'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/listen-3.1.5/lib/listen/adapter/linux.rb:32:in `_configure'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/listen-3.1.5/lib/listen/adapter/base.rb:45:in `block in configure'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/listen-3.1.5/lib/listen/adapter/base.rb:40:in `each'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/listen-3.1.5/lib/listen/adapter/base.rb:40:in `configure'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/listen-3.1.5/lib/listen/adapter/base.rb:63:in `start'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/forwardable.rb:229:in `start'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/listen-3.1.5/lib/listen/listener.rb:68:in `block in <class:Listener>'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/listen-3.1.5/lib/listen/fsm.rb:121:in `instance_eval'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/listen-3.1.5/lib/listen/fsm.rb:121:in `call'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/listen-3.1.5/lib/listen/fsm.rb:91:in `transition_with_callbacks!'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/listen-3.1.5/lib/listen/fsm.rb:57:in `transition'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/listen-3.1.5/lib/listen/listener.rb:91:in `start'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/guard-2.15.0/lib/guard/commander.rb:35:in `start'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/guard-2.15.0/lib/guard/cli/environments/valid.rb:16:in `start_guard'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/guard-2.15.0/lib/guard/cli.rb:122:in `start'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/guard-2.15.0/lib/guard/aruba_adapter.rb:32:in `execute'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/guard-2.15.0/lib/guard/aruba_adapter.rb:19:in `execute!'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/guard-2.15.0/bin/_guard-core:11:in `<main>'

# sleep command should be killed, but it alive.
$ ps 
  PID TTY          TIME CMD
 6903 pts/31   00:00:01 zsh
 7997 pts/31   00:00:00 sleep
 8010 pts/31   00:00:00 ps
```


I guess it is also a bug of guard or listen. But I think the process cleanup is nesessary even if the permission bug is solved.

---


I'll write tests for this pull request if it is acceptable and we need tests.

Thanks for the great product!