### PR TITLE
CI: Use jruby-9.2.8.0 and pick openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.5.5
   - 2.6.2
   - jruby-9.1.17.0
-  - jruby-9.2.6.0
+  - jruby-9.2.8.0
   - rbx-3.107
 matrix:
   allow_failures:
@@ -13,6 +13,8 @@ matrix:
 env:
   global:
     - JRUBY_OPTS="--debug"
+jdk:
+  - openjdk8
 script:
   - bundle exec rake
 bundler_args: --without development


### PR DESCRIPTION

This PR updates the CI matrix to use latest JRuby, **9.2.8.0**.

[JRuby 9.2.8.0 release blog post](https://www.jruby.org/2019/08/12/jruby-9-2-8-0.html)

  - The use of openjdk8 allows us to wait with all the --allow-opens needed to run with a newer JDK