### PR TITLE
Don't swallow evaluator error by handling non-existant listener & interactor

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ inherit_from:
 
 # Files you want to exclude
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
   Exclude:
     - vendor/**/*
     - db/schema.rb

--- a/lib/guard/commander.rb
+++ b/lib/guard/commander.rb
@@ -53,8 +53,8 @@ module Guard
     end
 
     def stop
-      listener.stop
-      interactor.background
+      listener&.stop
+      interactor&.background
       UI.debug "Guard stops all plugins"
       Runner.new.run(:stop)
       Notifier.disconnect

--- a/spec/lib/guard/commander_spec.rb
+++ b/spec/lib/guard/commander_spec.rb
@@ -96,6 +96,22 @@ RSpec.describe Guard::Commander do
         expect { Guard.start }.to raise_error(RuntimeError)
       end
     end
+
+    context "when setup raises an error" do
+      it "calls Commander#stop" do
+        # Reproduce a case where an error is raised during Guardfile evaluation
+        # before the listener and interactor are instantiated.
+        expect(Guard).to receive(:listener).and_return(nil)
+        expect(Guard).to receive(:interactor).and_return(nil)
+        expect(Guard).to receive(:setup).and_raise(RuntimeError)
+
+        # From stop()
+        expect(runner).to receive(:run).with(:stop)
+        expect(Guard::UI).to receive(:info).with("Bye bye...", reset: true)
+
+        expect { Guard.start }.to raise_error(RuntimeError)
+      end
+    end
   end
 
   describe ".stop" do


### PR DESCRIPTION
This should fix https://github.com/guard/guard/issues/937.