### PR TITLE
Maintain release notes using GitHub Actions

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,17 @@
+name-template: "v$NEXT_PATCH_VERSION"
+tag-template: "v$NEXT_PATCH_VERSION"
+categories:
+  - title: "⚠️ Breaking Changes"
+    label: "⚠️ Breaking"
+  - title: "✨ New Features"
+    label: "✨ Feature"
+  - title: "🐛 Bug Fixes"
+    label: "🐛 Bug Fix"
+  - title: "📚 Documentation"
+    label: "📚 Docs"
+  - title: "🏠 Housekeeping"
+    label: "🏠 Housekeeping"
+change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
+no-changes-template: "- No changes"
+template: |
+  $CHANGES

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,12 @@
+on: push
+name: Push
+jobs:
+  draftRelease:
+    name: Draft Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Draft Release
+        uses: toolmantim/release-drafter@v5.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,5 +53,13 @@ Pull requests are very welcome! Please try to follow these simple rules if appli
 * Update the [README](https://github.com/guard/guard/blob/master/README.md).
 * Please **do not change** the version number.
 
+The title of your PR will automatically be included in the release notes for the next version of the gem. A maintainer can add one of the following GitHub labels to the PR to automatically categorize it when the release notes are generated:
+
+- ⚠️ Breaking
+- ✨ Feature
+- 🐛 Bug Fix
+- 📚 Docs
+- 🏠 Housekeeping
+
 For questions please join us in our [Google group](http://groups.google.com/group/guard-dev) or on
 `#guard` (irc.freenode.net).

--- a/README.md
+++ b/README.md
@@ -151,6 +151,25 @@ Before reporting a problem, please read how to [File an issue](https://github.co
 ## Development / Contributing
 
 See the [Contributing Guide](https://github.com/guard/guard/blob/master/CONTRIBUTING.md#development).
+
+## Releasing
+
+### Prerequisites
+
+* You must have commit rights to the GitHub repository.
+* You must have push rights for rubygems.org.
+
+### How to release
+
+1. Run `bundle install` to make sure that you have all the gems necessary for testing and releasing.
+2.  **Ensure all tests are passing by running `bundle exec rake`.**
+3. Determine which would be the correct next version number according to [semver](http://semver.org/).
+4. Update the version in `./lib/guard/version.rb`.
+5. Update the version in the Install section of `./README.md` (`gem 'guard', '~> X.Y'`).
+6. Commit the version in a single commit, the message should be "Preparing vX.Y.Z"
+7. Run `bundle exec rake release:full`; this will tag, push to GitHub, and publish to rubygems.org.
+8. Update and publish the release notes on the [GitHub releases page](https://github.com/guard/guard/releases) if necessary.
+
 ### Author
 
 [Thibaud Guillaume-Gentil](https://github.com/thibaudgg) ([@thibaudgg](https://twitter.com/thibaudgg))


### PR DESCRIPTION
Similarly to https://github.com/guard/listen/pull/466.

This commit sets up a GitHub Actions workflow that uses Release Drafter to automatically maintain release notes on every push.

In practice this means that contributors no longer have to manually update the CHANGELOG, which is something that is easy to forget and often introduces tedious merge conflicts.

Instead, Release Drafter automatically adds the title of the PR to the GitHub release notes to a draft release, crediting the author of the PR, and linking to the PR number. Release Drafter furthermore organizes the release notes into sections according to the labels assigned to the PRs:

- ⚠️ Breaking
- 🐛 Bug Fix
- 📚 Docs
- ✨ Feature
- 🏠 Housekeeping

This also simplifies the release process for maintainers: instead of manually updating the CHANGELOG, all you have to do is press "publish" on the release draft on GitHub.

As part of this commit I have documented the release process in `README.md` and the PR labeling process in `CONTRIBUTING.md`.

Before merging this PR a project administrator will need to create the following labels using [this GitHub page](https://github.com/guard/listen/labels):

|Label name|Description|Color|
|----------|-----------|-----|
|⚠️ Breaking|Introduces a backwards-incompatible change|#d12d1b|
|🐛 Bug Fix|Fixes a bug|#c0fc80|
|📚 Docs|Improves documentation|#bfdadc|
|✨ Feature|Adds a new feature|#ba1ecc|
|🏠 Housekeeping|Non-user facing cleanup and maintenance|#ccccff|