### PR TITLE
Remove the link to Google+ community page

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ any questions about Guard or want to share some information with the Guard commu
 the following places:
 
 * [Guard Wiki](https://github.com/guard/guard/wiki)
-* [Google+ community](https://plus.google.com/communities/110022199336250745477).
 * [Google group](http://groups.google.com/group/guard-dev).
 * [StackOverflow](http://stackoverflow.com/questions/tagged/guard).
 * IRC channel `#guard` (irc.freenode.net) for chatting.


### PR DESCRIPTION
## What? 

This PR removes the link to Google+ community page from README.md.

## Why?

As explained in <https://plus.google.com/communities/110022199336250745477>, Google+ has been closed in April 2019 and we cannot read the community page any longer.