### PR TITLE
fix pry

### DIFF
--- a/lib/guard/jobs/pry_wrapper.rb
+++ b/lib/guard/jobs/pry_wrapper.rb
@@ -134,7 +134,12 @@ module Guard
         Pry.config.should_load_rc = false
         Pry.config.should_load_local_rc = false
         history_file_path = options[:history_file] || HISTORY_FILE
-        Pry.config.history.file = File.expand_path(history_file_path)
+        
+        if Pry.respond_to?(:file)
+          Pry.config.history.file = File.expand_path(history_file_path)
+        else
+          Pry.config.history_file = File.expand_path(history_file_path)
+        end
 
         _add_hooks(options)
 

--- a/lib/guard/jobs/pry_wrapper.rb
+++ b/lib/guard/jobs/pry_wrapper.rb
@@ -135,10 +135,10 @@ module Guard
         Pry.config.should_load_local_rc = false
         history_file_path = options[:history_file] || HISTORY_FILE
         
-        if Pry.config.try(:history).respond_to?(:file)
-          Pry.config.history.file = File.expand_path(history_file_path)
-        else
+        if Pry.config.respond_to?(:history_file)
           Pry.config.history_file = File.expand_path(history_file_path)
+        else
+          Pry.config.history.file = File.expand_path(history_file_path)
         end
 
         _add_hooks(options)

--- a/lib/guard/jobs/pry_wrapper.rb
+++ b/lib/guard/jobs/pry_wrapper.rb
@@ -134,7 +134,7 @@ module Guard
         Pry.config.should_load_rc = false
         Pry.config.should_load_local_rc = false
         history_file_path = options[:history_file] || HISTORY_FILE
-        
+
         if Pry.config.respond_to?(:history_file)
           Pry.config.history_file = File.expand_path(history_file_path)
         else

--- a/lib/guard/jobs/pry_wrapper.rb
+++ b/lib/guard/jobs/pry_wrapper.rb
@@ -135,7 +135,7 @@ module Guard
         Pry.config.should_load_local_rc = false
         history_file_path = options[:history_file] || HISTORY_FILE
         
-        if Pry.respond_to?(:file)
+        if Pry.config.&history.respond_to?(:file)
           Pry.config.history.file = File.expand_path(history_file_path)
         else
           Pry.config.history_file = File.expand_path(history_file_path)

--- a/lib/guard/jobs/pry_wrapper.rb
+++ b/lib/guard/jobs/pry_wrapper.rb
@@ -135,7 +135,7 @@ module Guard
         Pry.config.should_load_local_rc = false
         history_file_path = options[:history_file] || HISTORY_FILE
         
-        if Pry.config.&history.respond_to?(:file)
+        if Pry.config.try(:history).respond_to?(:file)
           Pry.config.history.file = File.expand_path(history_file_path)
         else
           Pry.config.history_file = File.expand_path(history_file_path)


### PR DESCRIPTION
On the latest version of Mac OS and ruby 2.6.5, pry appears to have the following error:

```bash
gems/ruby-2.6.5/gems/guard-2.16.1/lib/guard/jobs/pry_wrapper.rb:131:in `_setup': undefined method `file=' for #<Pry::History:0x00007faf61848420>
```