### PR TITLE
Bump VERSION to 2.16.2

### DIFF
--- a/lib/guard/version.rb
+++ b/lib/guard/version.rb
@@ -1,3 +1,3 @@
 module Guard
-  VERSION = "2.16.1"
+  VERSION = "2.16.2"
 end


### PR DESCRIPTION
This version will include the fix for Pry > 0.13 (https://github.com/guard/guard/pull/958).