### PR TITLE
Refactor pry_wrapper.rb to be XDG compliant

### DIFF
--- a/lib/guard/jobs/pry_wrapper.rb
+++ b/lib/guard/jobs/pry_wrapper.rb
@@ -45,11 +45,21 @@ module Guard
     class PryWrapper < Base
       # The default Ruby script to configure Guard Pry if the option `:guard_rc`
       # is not defined.
-      GUARD_RC = "~/.guardrc"
+
+      GUARD_RC = if ENV["XDG_CONFIG_HOME"] && File.exist?(ENV["XDG_CONFIG_HOME"] + "/guard/guardrc")
+                   ENV["XDG_CONFIG_HOME"] + "/guard/guardrc"
+                 else
+                   "~/.guardrc"
+                 end
 
       # The default Guard Pry history file if the option `:history_file` is not
       # defined.
-      HISTORY_FILE = "~/.guard_history"
+
+      HISTORY_FILE = if ENV["XDG_DATA_HOME"] && File.exist?(ENV["XDG_DATA_HOME"] + "/guard/history")
+                       ENV["XDG_DATA_HOME"] + "/guard/history"
+                     else
+                       "~/.guard_history"
+                     end
 
       # List of shortcuts for each interactor command
       SHORTCUTS = {


### PR DESCRIPTION
The XDG Base Directory Specification (which is currently used by
FOSS projects such as Git, Tmux, Pry, Rspec) provides a default
location for various file formats, including config/rc/history files.

This comment refactors pry_wrapper.rb to load GUARD_RC and
HISTORY_FILE from XDG_CONFIG_HOME and XDG_DATA_HOME
respectively if they are both set and the corresponding files exist
within the guard subdirectory within the XDG locations.

To maintain backwards compatibility it defaults back to ~/.guardrc
and ~/.guard_history if the respective XDG environment variable does
not exist or there is no corresponding file.