### PR TITLE
Update pry version dependency

### DIFF
--- a/guard.gemspec
+++ b/guard.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_runtime_dependency "lumberjack", ">= 1.0.12", "< 2.0"
   s.add_runtime_dependency "nenv", "~> 0.1"
   s.add_runtime_dependency "notiffany", "~> 0.0"
-  s.add_runtime_dependency "pry", ">= 0.9.12"
+  s.add_runtime_dependency "pry", ">= 0.11.0"
   s.add_runtime_dependency "shellany", "~> 0.0"
   s.add_runtime_dependency "thor", ">= 0.18.1"
 


### PR DESCRIPTION
There is a dependency on the Pry:Prompt constructor that was updated in version 11.

```
/usr/local/bundle/gems/guard-2.16.2/lib/guard/jobs/pry_wrapper.rb:284:in `initialize': wrong number of arguments (given 3, expected 0) (ArgumentError)
        from /usr/local/bundle/gems/guard-2.16.2/lib/guard/jobs/pry_wrapper.rb:284:in `new'
        from /usr/local/bundle/gems/guard-2.16.2/lib/guard/jobs/pry_wrapper.rb:284:in `_configure_prompt'
        from /usr/local/bundle/gems/guard-2.16.2/lib/guard/jobs/pry_wrapper.rb:151:in `_setup'
        from /usr/local/bundle/gems/guard-2.16.2/lib/guard/jobs/pry_wrapper.rb:68:in `initialize'
        from /usr/local/bundle/gems/guard-2.16.2/lib/guard/interactor.rb:17:in `new'
        from /usr/local/bundle/gems/guard-2.16.2/lib/guard/interactor.rb:17:in `initialize'
        from /usr/local/bundle/gems/guard-2.16.2/lib/guard.rb:67:in `new'
        from /usr/local/bundle/gems/guard-2.16.2/lib/guard.rb:67:in `setup'
        from /usr/local/bundle/gems/guard-2.16.2/lib/guard/commander.rb:32:in `start'
        from /usr/local/bundle/gems/guard-2.16.2/lib/guard/cli/environments/valid.rb:16:in `start_guard'
        from /usr/local/bundle/gems/guard-2.16.2/lib/guard/cli.rb:122:in `start'
        from /usr/local/bundle/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
        from /usr/local/bundle/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
        from /usr/local/bundle/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
        from /usr/local/bundle/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
        from /usr/local/bundle/gems/guard-2.16.2/lib/guard/aruba_adapter.rb:32:in `execute'
        from /usr/local/bundle/gems/guard-2.16.2/lib/guard/aruba_adapter.rb:19:in `execute!'
        from /usr/local/bundle/gems/guard-2.16.2/bin/_guard-core:11:in `<main>'
```