### PR TITLE
Bump version to 2.16.3

### DIFF
--- a/lib/guard/version.rb
+++ b/lib/guard/version.rb
@@ -1,3 +1,3 @@
 module Guard
-  VERSION = "2.16.2"
+  VERSION = "2.16.3"
 end


### PR DESCRIPTION
* Refactor pry_wrapper.rb to be XDG compliant (#962) 
* Add Ruby 2.7.3 and 3.0.1 to the test matrix (#969)
* Bring compatibility with Ruby 3 explicit keyword arguments (#969)