### PR TITLE
CI: Update build matrix patch versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ os: linux
 language: ruby
 
 rvm:
-  - 2.4.9
-  - 2.5.7
-  - 2.6.5
+  - 2.4.10
+  - 2.5.9
+  - 2.6.7
   - 2.7.3
   - 3.0.1
-  - jruby-9.2.8.0
+  - jruby-9.2.17.0
 
 jdk:
   - openjdk8


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.

Source for version numbers: https://github.com/rvm/rvm/blob/master/config/known