### PR TITLE
pry 0.13.0

### DIFF
--- a/guard.gemspec
+++ b/guard.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_runtime_dependency "lumberjack", ">= 1.0.12", "< 2.0"
   s.add_runtime_dependency "nenv", "~> 0.1"
   s.add_runtime_dependency "notiffany", "~> 0.0"
-  s.add_runtime_dependency "pry", ">= 0.9.12"
+  s.add_runtime_dependency "pry", ">= 0.13.0"
   s.add_runtime_dependency "shellany", "~> 0.0"
   s.add_runtime_dependency "thor", ">= 0.18.1"
 


### PR DESCRIPTION
Trying to bump the required `pry` version so people can bump their `pry-byebug` version to remove this warning. ([fixed](https://github.com/deivid-rodriguez/pry-byebug/blob/bf28c9781c434b2f00a83130ec5a8a992a691183/lib/pry-byebug/control_d_handler.rb#L1-L9))
<img width="924" alt="Screen Shot 2021-07-14 at 09 58 47" src="https://user-images.githubusercontent.com/1557529/125545406-c8e110e8-288b-4d1a-8f7f-23e459335147.png">
