### PR TITLE
Update URL of the project homepage

### DIFF
--- a/guard.gemspec
+++ b/guard.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.license = "MIT"
   s.authors = ["Thibaud Guillaume-Gentil"]
   s.email = ["thibaud@thibaud.gg"]
-  s.homepage = "http://guardgem.org"
+  s.homepage = "https://guard.github.io/guard/"
   s.summary = "Guard keeps an eye on your file modifications"
   s.description = "Guard is a command line tool to easily handle events"\
     " on file system modifications."


### PR DESCRIPTION
Since DocumentUp is down and the `guardgem.org` domain hasn't been renewed, let's go back to plain old GitHub pages.

Fixes https://github.com/guard/guard/issues/977.