### PR TITLE
Drop unused require ostruct to avoid a Ruby warning,

### DIFF
--- a/lib/guard/dsl_describer.rb
+++ b/lib/guard/dsl_describer.rb
@@ -7,7 +7,6 @@ require "guard/notifier"
 require "guard/plugin_util"
 
 require "set"
-require "ostruct"
 
 module Guard
   # @private


### PR DESCRIPTION
This library will no longer be shipped with Ruby 3.5.0, and will emit a warning.

In the source code, this was unused.