### PR TITLE
Get rid of compatibility warnings under Ruby 3.4.

### DIFF
--- a/guard.gemspec
+++ b/guard.gemspec
@@ -19,9 +19,11 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
 
   s.add_runtime_dependency "formatador", ">= 0.2.4"
   s.add_runtime_dependency "listen", ">= 2.7", "< 4.0"
+  s.add_runtime_dependency "logger", "~> 1.6"
   s.add_runtime_dependency "lumberjack", ">= 1.0.12", "< 2.0"
   s.add_runtime_dependency "nenv", "~> 0.1"
   s.add_runtime_dependency "notiffany", "~> 0.0"
+  s.add_runtime_dependency "ostruct", "~> 0.6"
   s.add_runtime_dependency "pry", ">= 0.13.0"
   s.add_runtime_dependency "shellany", "~> 0.0"
   s.add_runtime_dependency "thor", ">= 0.18.1"


### PR DESCRIPTION
When running guard 2.19.0 under Ruby 3.4.0rc1, Ruby prints warnings about upcoming incompatibility:

```
$ guard
~/dev/gems/guard/lib/guard.rb:2: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.
~/dev/gems/guard/bin/_guard-core:11: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
23:57:58 - INFO - Guard::RSpec is running
23:57:58 - INFO - Guard is now watching at '...'
```

When `logger` and `ostruct` gems are explicitly added as dependencies in the `guard.gemspec`, the warnings are no longer printed:

```
$ guard
00:01:00 - INFO - Guard::RSpec is running
00:01:00 - INFO - Guard is now watching at '...'
```

---

Environment:

```
Ubuntu Linux 24.04.1 LTS
ruby 3.4.0rc1 (2024-12-12 master 29caae9991) +PRISM [x86_64-linux]
Guard version 2.19.0
```

---

Should I add a PR for `2-stable` branch?