### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/guard

### DIFF
--- a/guard.gemspec
+++ b/guard.gemspec
@@ -38,4 +38,6 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
 
   s.executables = %w[guard _guard-core]
   s.require_path = "lib"
+
+  s.metadata["changelog_uri"] = "https://github.com/guard/guard/releases"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/guard which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/#metadata