### PR TITLE
fix usage of deprecated Lumberjack method

### DIFF
--- a/lib/guard/runner.rb
+++ b/lib/guard/runner.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "lumberjack"
+require "securerandom"
 
 require "guard/ui"
 require "guard/watcher"
@@ -29,7 +30,7 @@ module Guard
         UI.info "Unknown scopes: #{unknown.join(', ')}"
       end
 
-      Lumberjack.unit_of_work do
+      Lumberjack.tag(unit_of_work: SecureRandom.hex(6)) do
         grouped_plugins = session.grouped_plugins(scopes)
         grouped_plugins.each_value do |plugins|
           _run_group_plugins(plugins) do |plugin|

--- a/lib/guard/runner.rb
+++ b/lib/guard/runner.rb
@@ -30,7 +30,7 @@ module Guard
         UI.info "Unknown scopes: #{unknown.join(', ')}"
       end
 
-      Lumberjack.tag(unit_of_work: SecureRandom.hex(6)) do
+      Lumberjack.context do
         grouped_plugins = session.grouped_plugins(scopes)
         grouped_plugins.each_value do |plugins|
           _run_group_plugins(plugins) do |plugin|

--- a/lib/guard/runner.rb
+++ b/lib/guard/runner.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lumberjack"
-require "securerandom"
 
 require "guard/ui"
 require "guard/watcher"

--- a/spec/lib/guard/runner_spec.rb
+++ b/spec/lib/guard/runner_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Guard::Runner, :stub_ui do
     end
 
     it "marks an action as unit of work" do
-      expect(Lumberjack).to receive(:tag).with(hash_including(:unit_of_work))
+      expect(Lumberjack).to receive(:context)
       subject.run(:my_task)
     end
 

--- a/spec/lib/guard/runner_spec.rb
+++ b/spec/lib/guard/runner_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Guard::Runner, :stub_ui do
     end
 
     it "marks an action as unit of work" do
-      expect(Lumberjack).to receive(:unit_of_work)
+      expect(Lumberjack).to receive(:tag).with(hash_including(:unit_of_work))
       subject.run(:my_task)
     end
 


### PR DESCRIPTION
Fixes #1003

`Lumberjack#unit_of_work` was deprecated, see https://github.com/bdurand/lumberjack/commit/23c2e905759f0b52d8fb2d5f81b555e7180252da

I chose to replace the deprecated method with `tag(unit_of_work: SecureRandom.hex(6))` because this is as close to the original code as possible. However, given how this method is used in `Guard::Runner`, I think you could also just use `#context`, but I will leave that decision to the maintainers. I'm more than happy to change my PR to use `#context` instead.