### PR TITLE
fix Kernel#caller backtrace format parsing for Ruby 3.4

### DIFF
--- a/lib/guard/plugin.rb
+++ b/lib/guard/plugin.rb
@@ -116,7 +116,7 @@ module Guard
     #
     def hook(event, *args)
       hook_name = if event.is_a? Symbol
-                    calling_method = caller(1..1).first[/`([^']*)'/, 1]
+                    calling_method = caller(1..1).first[/[`'](?:[^']*#)?([^']*)'/, 1]
                     "#{calling_method}_#{event}"
                   else
                     event

--- a/spec/lib/guard/plugin_spec.rb
+++ b/spec/lib/guard/plugin_spec.rb
@@ -221,5 +221,25 @@ RSpec.describe Guard::Plugin, :stub_ui do
 
       subject.stop
     end
+
+    # https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/#compatibility-issues
+    ["test.rb:1:in `foo': undefined method 'time' for an instance of Integer",
+     "test.rb:1:in 'Object#foo': undefined method 'time' for an instance of Integer"].each do |caller_line|
+      it "extracts method name from backtrace format: #{caller_line}" do
+        module Guard
+          class Dummy < Guard::Plugin
+            def foo
+              hook :begin
+            end
+          end
+        end
+
+        allow(subject).to receive(:caller).and_return([caller_line])
+
+        expect(described_class).to receive(:notify).with(subject, :foo_begin)
+
+        subject.foo
+      end
+    end
   end
 end


### PR DESCRIPTION
Ruby 3.4 changed the `Kernel#caller` output format to use single quotes around method labels (e.g. 'Foo#stop' instead of `stop') and to include the class qualifier with a '#' separator (Foo#stop instead of just stop). This patch updates the regex to accept both old (backtick) and new (single quote) delimiters and makes the class name prefix optional and non-capturing so only the method name is extracted.